### PR TITLE
Compatibility with pvlib 0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools_kwargs = {
     'install_requires': ['numpy >= 1.10.4',
                          'pandas >= 0.18.0',
                          'matplotlib',
-                         ],
+                         'jinja2'],
     'scripts': [],
     'include_package_data': True
 }


### PR DESCRIPTION
The pv_example now uses pvlib 0.4 directly to generate a sapm model.  The pecos function basic_pvlib_performance_model has been removed.