### PR TITLE
Updates to metrics and helper functions that convert index to/from datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![TravisCI](https://travis-ci.org/sandialabs/pecos.svg?branch=master)](https://travis-ci.org/sandialabs/pecos)
 [![Coverage Status](https://coveralls.io/repos/github/sandialabs/pecos/badge.svg?branch=master)](https://coveralls.io/github/sandialabs/pecos?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/pecos/badge/?version=latest)](http://pecos.readthedocs.org/en/latest/)
+[![Downloads](https://pepy.tech/badge/pecos)](https://pepy.tech/project/pecos)
 
 Advances in sensor technology have rapidly increased our ability to monitor 
 natural and human-made physical systems. In many cases, it is critical to 

--- a/documentation/applications.rst
+++ b/documentation/applications.rst
@@ -7,26 +7,27 @@ can be added by inheriting from the PerformanceMonitoring class.
 
 PV system monitoring
 ---------------------
-For photovoltaic (PV) systems, the translation dictionary can be used to group data
+Pecos was originally developed to monitor photovoltaic (PV) systems as part of the 
+`Department of Energy Regional Test Centers <https://www.energy.gov/eere/solar/regional-test-centers-solar-technologies>`_.
+Pecos is used to run daily analysis on data collected at several sites across the US.
+For PV systems, the translation dictionary can be used to group data
 according to the system architecture, which can include multiple strings and modules.
 The time filter can be defined based on sun position and system location.
 The data objects used in Pecos are compatible with PVLIB, which can be used to model PV 
 systems [SHFH16]_ (http://pvlib-python.readthedocs.io/).
 Pecos also includes functions to compute PV specific metrics (i.e. insolation, 
 performance ratio, clearness index) in the :class:`~pecos.pv` module.
-
 The International Electrotechnical Commission (IEC) has developed guidance to measure 
 and analyze energy production from PV systems. 
 [KlSC17]_ describes an application of the standards outlined in IEC 61724-3, using 
 Pecos and PVLIB.
-
-Pecos includes a PV system example, **pv_example.py**, in the examples/pv directory.  
-The example uses graphics functions in **pv_graphics.py**.
+Pecos includes a PV system example in the `examples/pv <https://github.com/sandialabs/pecos/tree/master/examples/pv>`_ directory.  
 
 Performance metrics
 ---------------------
-The performance metrics, created by Pecos, can be used in additional 
-analysis to track system health over time.
-Pecos includes a performance metrics example (based on PV metrics), **metrics_example.py**, 
-in the examples/metrics directory.
-
+Pecos is typically used to run a series of quality control tests on data collected 
+over a set time interval (i.e. hourly, daily, weekly).
+The metrics that are generated from each analysis can be used in additional 
+quality control analysis to track long term performance and system health (i.e. yearly summary reports).
+Pecos includes a performance metrics example (based on one year of PV metrics)
+in the `examples/metrics <https://github.com/sandialabs/pecos/tree/master/examples/metrics>`_ directory.

--- a/documentation/composite_signal.rst
+++ b/documentation/composite_signal.rst
@@ -43,7 +43,7 @@ the PerformanceMonitoring object.
 	
 .. doctest::
 
-    >>> elapsed_time= pm.get_elapsed_time()
-    >>> wave_model = np.sin(10*(elapsed_time/86400))
-    >>> wave_model.columns=['Wave Model']
+    >>> clocktime = pecos.utils.datetime_to_clocktime(pm.df.index)
+    >>> wave_model = pd.DataFrame(np.sin(10*(clocktime/86400)), 
+    ...                           index=pm.df.index, columns=['Wave Model'])
     >>> pm.add_dataframe(wave_model)

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -37,10 +37,11 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
-    'numpydoc',
+    'sphinx.ext.napoleon',
     'sphinx.ext.intersphinx',
 ]
 
+napoleon_use_rtype = False
 viewcode_import = True
 numpydoc_show_class_members = True
 numpydoc_class_members_toctree = False

--- a/documentation/configfile.rst
+++ b/documentation/configfile.rst
@@ -7,13 +7,13 @@ therefore there are no specific formatting requirements.**
 Configuration files can be useful when using the same Python script 
 to analyze several systems that have slightly different input requirements.
 
-The examples/simple directory includes a configuration file, **simple_config.yml**, that defines 
+The `examples/simple <https://github.com/sandialabs/pecos/tree/master/examples/simple>`_ directory includes a configuration file, **simple_config.yml**, that defines 
 system specifications, 
 translation dictionary,
 composite signals,
 corrupt values,
 and bounds for range and increment tests.
-The script, **simple_example_using_config.py**, in the examples/simple directory uses this
+The script, **simple_example_using_config.py** uses this
 configuration file to run the simple example.
 
 .. literalinclude:: ../examples/simple/simple_config.yml

--- a/documentation/example.rst
+++ b/documentation/example.rst
@@ -3,7 +3,7 @@
 Simple example
 ================
 
-A simple example is included in the examples/simple directory.  
+A simple example is included in the `examples/simple <https://github.com/sandialabs/pecos/tree/master/examples/simple>`_ directory.  
 This example uses data from an excel file, **simple.xlsx**, which 
 contains 4 columns of data (A through D). 
 
@@ -45,7 +45,7 @@ The script performs the following steps:
 
 * Run quality control tests
 
-* Save test results and performance metrics to CSV files
+* Save test results to a CSV files
 
 * Generate an HTML report
 
@@ -53,11 +53,9 @@ The script performs the following steps:
 
 Results include:
 
-* HTML monitoring report, **monitoring_report.html** (:numref:`fig-monitor-1`), includes summary tables and graphics
+* HTML monitoring report, **monitoring_report.html** (:numref:`fig-monitor-1`), includes quality control index, summary table, and graphics
 
 * Test results CSV file, **test_results.csv**, includes information from the summary tables
-
-* Performance metric CSV file, **metrics.csv**, includes a quality control index based on the analysis.  
 
 .. _fig-monitor-1:
 .. figure:: figures/monitoring_report.png

--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -8,7 +8,6 @@ are recommended to manage the Python interface.
 Anaconda Python distributions include the Python packages needed to run Pecos.
 
 Pecos can be installed using pip, git, or a downloaded zip file.  
-Note that the pip installation will NOT include the examples folder referenced in this manual.
 
 **pip:** To install Pecos using pip::
 

--- a/documentation/metrics.rst
+++ b/documentation/metrics.rst
@@ -1,9 +1,10 @@
-Performance metrics
+Metrics
 ==========================
 
-Pecos includes several metrics that describe the quality control analysis or compute quantities 
-that might be of use in the analysis. Many of these metrics aggregates over time and can be saved
-to track long term performance and system health.
+Pecos includes several metrics that describe the quality control analysis or 
+compute quantities that might be of use in the analysis. 
+Many of these metrics aggregates over time and can be saved to track long 
+term performance and system health.
 
 Quality control index
 -------------------------
@@ -12,8 +13,9 @@ percent of data points that pass quality control tests.
 Duplicate and non-monotonic indexes are not counted as failed tests 
 (duplicates are removed and non-monotonic indexes are reordered).  
 A value of 1 indicates that all data passed all tests.  
-For example, if the data consists of 10 columns and 720 times and 
-7000 data points pass all quality control tests, then the QCI is (7000/(10*720)) = 0.972.
+QCI is computed for each column of data.                                 
+For example, if the data contains 720 entries and 
+700 pass all quality control tests, then the QCI is 700/720 = 0.972.
 QCI is computed using the :class:`~pecos.metrics.qci` method.
 
 To compute QCI,
@@ -39,29 +41,45 @@ Root mean square error
 
 The root mean squared error (RMSE) is used to compare the 
 difference between two variables.  
-RMSE is often used to compare measured to modeled data.
+RMSE is computed for each column of data (note, the column names in the two data sets must be equal).
+This metric is often used to compare measured to modeled data.
 RMSE is computed using the :class:`~pecos.metrics.rmse` method.
 	
 Time integral
 -------------------------
 
-A time integral is used to integrate over time-series data.
-For example, time integrals can be used to compute energy from power, or insolation from irradiance.
-A time integral is computed using the :class:`~pecos.metrics.time_integral` method.
+The integral is computed using the trapezoidal rule and is computed using 
+the :class:`~pecos.metrics.time_integral` method.
+The integral is computed for each column of data.
+
+Time derivative
+-------------------------
+
+The derivative is computed using central differences and is computed using 
+the :class:`~pecos.metrics.time_derivative` method.
+The derivative is computed for each column of data.              
 
 Probability of detection and false alarm rate 
 -------------------------------------------------
 
 The probability of detection (PD) and false alarm rate (FAR) are used to
-evaluate how well a quality control test (or set of quality control tests) distinguishes background from anomalous conditions.
-PD and FAR are related to the number of true negatives, false negatives, false positives, and true positives, as shown in :numref:`fig-FAR-PD`.
-The estimated condition is computed using results from quality control tests in Pecos, the actual condition must be supplied by the user.
-If actual conditions are not known, anomalous conditions can be superimposed in the raw data to generate a testing data set.
+evaluate how well a quality control test (or set of quality control tests) 
+distinguishes background from anomalous conditions.
+PD and FAR are related to the number of true negatives, false negatives, false 
+positives, and true positives, as shown in :numref:`fig-FAR-PD`.
+The estimated condition can be computed using results from quality control tests in 
+Pecos, the actual condition must be supplied by the user.
+If actual conditions are not known, anomalous conditions can be superimposed 
+in the raw data to generate a testing data set.
 A "good" quality control test (or tests) result in a PD close to 1 and FAR close to 0.
 
-Receiver Operating Characteristic (ROC) curves are used to compare the effectiveness of different quality control tests, as shown in :numref:`fig-ROC`.
-To generate a ROC curve, quality control test input parameters (i.e. upper bound for a range test) are systematically adjusted.
-PD and FAR are computed using the :class:`~pecos.metrics.probability_of_detection` and :class:`~pecos.metrics.false_alarm_rate` methods.
+Receiver Operating Characteristic (ROC) curves are used to compare the 
+effectiveness of different quality control tests, as shown in :numref:`fig-ROC`.
+To generate a ROC curve, quality control test input parameters (i.e. upper 
+bound for a range test) are systematically adjusted.
+PD and FAR are computed using the :class:`~pecos.metrics.probability_of_detection` 
+and :class:`~pecos.metrics.false_alarm_rate` methods.
+These metrics are computed for each column of data.
 
 .. _fig-FAR-PD:
 .. figure:: figures/PD-FAR.png

--- a/documentation/results.rst
+++ b/documentation/results.rst
@@ -3,7 +3,8 @@
 Results
 ==========
 
-Pecos can be used to collect quality control test results and performance metrics, and generate HTML reports and dashboards.
+Pecos can be used to collect quality control test results and performance 
+metrics, and generate HTML reports and dashboards.
 
 Quality control test results
 ------------------------------
@@ -105,13 +106,12 @@ Possible strategies include:
 These strategies can be accomplished using the Pandas methods ``interpolate``, ``replace``, and ``fillna``.  
 See Pandas documentation for more details.
 
-Performance metrics
+Metrics
 -----------------------------
 
-The :class:`~pecos.io.write_metrics` method is used to write performance metrics to a CSV file.
+The :class:`~pecos.io.write_metrics` method is used to write metrics that describe the quality control analysis (i.e. QCI) to a CSV file.
 This method can be customized to write performance metrics to a database or to other file formats.
 The method can be called multiple times to appended metrics based on the timestamp of the DataFrame.
-:numref:`fig-metrics` shows a simple example where two metrics DataFrames are appended in a single file.
 
 .. doctest::
     :hide:
@@ -207,8 +207,7 @@ For each row and column in the dashboard, the following information can be speci
 * Links (i.e. the path to a monitoring report or other file/site for additional information)
 
 Text, graphics, tables, and links can be combined to create custom dashboards.
-Pecos includes dashboard examples (**dashboard_example_1.py**, **dashboard_example_2.py**, and 
-**dashboard_example_3.py**) in the examples/dashboard directory.
+Pecos includes dashboard examples in the `examples/dashboard <https://github.com/sandialabs/pecos/tree/master/examples/dashboard>`_ directory. 
 :numref:`fig-dashboard1`, :numref:`fig-dashboard2`, and  :numref:`fig-dashboard3` show example dashboards generated using Pecos.
 
 .. _fig-dashboard1:

--- a/documentation/timefilter.rst
+++ b/documentation/timefilter.rst
@@ -23,8 +23,9 @@ The following example defines a time filter between 3 AM and 9 PM,
 	
 .. doctest::
 
-    >>> clock_time = pm.get_clock_time()
-    >>> time_filter = (clock_time > 3*3600) & (clock_time < 21*3600)
+    >>> clocktime = pecos.utils.datetime_to_clocktime(pm.df.index)
+    >>> time_filter = pd.Series((clocktime > 3*3600) & (clocktime < 21*3600), 
+    ...                         index=pm.df.index)
 
 The time filter can also be defined based on properties of the DataFrame, for example,
 

--- a/documentation/timefilter.rst
+++ b/documentation/timefilter.rst
@@ -32,7 +32,9 @@ The time filter can also be defined based on properties of the DataFrame, for ex
 
     >>> time_filter = pm.df['A'] > 0.5
 	
-For some applications, it is useful to define the time filter based on sun position, as demonstrated in **pv_example.py** in the examples/pv directory.
+For some applications, it is useful to define the time filter based on sun position, 
+as demonstrated in **pv_example.py** in the 
+`examples/pv <https://github.com/sandialabs/pecos/tree/master/examples/pv>`_ directory.
 
 The time filter can then be added to the PerformanceMonitoring object as follows,
 

--- a/documentation/whatsnew/v0.1.8.rst
+++ b/documentation/whatsnew/v0.1.8.rst
@@ -6,7 +6,7 @@ v0.1.8 (master)
 * Added properties to the PerformanceMonitoring object to return the following:
 
   * Boolean mask, ``pm.mask``.  Indicates data that failed a quality control test. This
-    replaces the method ``get_test_results_mask``, API change.
+    replaces the method ``get_test_results_mask``(API change).
   * Cleaned data, ``pm.cleaned_data``. Data that failed a quality control test are replaced by NaN.
 
 * Added the ability to run quality control tests as individual functions.  
@@ -23,5 +23,14 @@ v0.1.8 (master)
   ``write_metrics``, 
   ``write_test_results``, and
   ``plot_test_results``. 
+* Updated metrics:
+
+  * Added time_derivative which returns a derivative timeseries for each column of data
+  * ``qci``, ``rmse``, ``time_integral``, ``probability_of_detection``, and 
+    ``false_alarm_rate`` now return 1 value per column of data (API change)
+  * pv metrics were also updated to return 1 value per column (API change)
+  * Deprecated per_day option. Data can be grouped by custom time intervals before 
+    computing metrics (API change)
+* Timestamp indexes down to millisecond resolution are supported
 * Added Python 3.7 tests
 * Updated examples, tests, and documentation

--- a/documentation/whatsnew/v0.1.8.rst
+++ b/documentation/whatsnew/v0.1.8.rst
@@ -32,5 +32,7 @@ v0.1.8 (master)
   * Deprecated per_day option. Data can be grouped by custom time intervals before 
     computing metrics (API change)
 * Timestamp indexes down to millisecond resolution are supported
+* Added additional helper functions in pecos.utils to convert to/from datetime indexes.
+  Methods ``get_elapsed_time`` and ``get_clock_time`` were removed from the PerformanceMonitoring class (API change).
 * Added Python 3.7 tests
 * Updated examples, tests, and documentation

--- a/examples/dashboard/dashboard_example_1.py
+++ b/examples/dashboard/dashboard_example_1.py
@@ -50,8 +50,10 @@ for location_name in locations:
         pm.check_timestamp(specs['Frequency']) 
         
         # Generate a time filter
-        clock_time = pm.get_clock_time()
-        time_filter = (clock_time > specs['Time Filter Min']*3600) & (clock_time < specs['Time Filter Max']*3600)
+        clock_time = pecos.utils.datetime_to_clocktime(pm.df.index)
+        time_filter = pd.Series((clock_time > specs['Time Filter Min']*3600) & \
+                                (clock_time < specs['Time Filter Max']*3600),
+                                index=pm.df.index)
         pm.add_time_filter(time_filter)
         
         # Check missing

--- a/examples/dashboard/dashboard_example_1.py
+++ b/examples/dashboard/dashboard_example_1.py
@@ -86,10 +86,9 @@ for location_name in locations:
                                          [custom_graphics_file], QCI, filename=report_file)
         
         # Store content to be displayed in the dashboard
-        metrics_table = QCI.transpose().to_html(bold_rows=False, header=False)
         content = {'text': "Example text for " + location_name+'_'+system_name, 
                    'graphics': [custom_graphics_file], 
-                   'table':  metrics_table, 
+                   'table':  QCI.to_frame('QCI').transpose().to_html(), 
                    'link': {'Link to Report': os.path.abspath(report_file)}}
         dashboard_content[(system_name, location_name)] = content
 

--- a/examples/dashboard/dashboard_example_2.py
+++ b/examples/dashboard/dashboard_example_2.py
@@ -68,7 +68,6 @@ for location_name in locations:
                                          [custom_graphics_file], QCI, filename=report_file)
         
         # Store content to be displayed in the dashboard
-        metrics_table = QCI.transpose().to_html(bold_rows=False, header=False)
         content = {'graphics': [colorblock_graphics_file],
                    'link': {'Link to Report': os.path.abspath(report_file)}}
         dashboard_content[(location_name, system_name)] = content

--- a/examples/dashboard/dashboard_example_3.py
+++ b/examples/dashboard/dashboard_example_3.py
@@ -8,7 +8,7 @@ from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.colors import rgb2hex
 import pecos
 
-# Color value used in Pandas Styling
+# Red/yellow/green color used in Pandas Styling
 def color_value(val):
     
     nThresholds = 10

--- a/examples/metrics/metrics_example.py
+++ b/examples/metrics/metrics_example.py
@@ -18,7 +18,6 @@ pecos.logger.initialize()
 pm = pecos.monitoring.PerformanceMonitoring()
 
 # Populate the object with a dataframe and translation dictionary
-system_name = 'System1'
 data_file = 'System1_2015_performance_metrics.xlsx'
 df = pd.read_excel(data_file, index_col=0)
 pm.add_dataframe(df)
@@ -33,12 +32,10 @@ pm.check_missing()
 pm.check_corrupt([-999]) 
 
 # Check range for all columns
-for key in pm.trans.keys():
-    pm.check_range([0.5,1], key)
+pm.check_range([0.5,1])
 
 # Check increment for all columns
-for key in pm.trans.keys():
-    pm.check_increment([-0.5, None], key, absolute_value=False) 
+pm.check_increment([-0.5, None], absolute_value=False) 
 
 # Generate graphics
 test_results_graphics = pecos.graphics.plot_test_results(pm.df, pm.test_results)
@@ -48,4 +45,4 @@ plt.savefig('custom.png', format='png', dpi=500)
 # Write test results and report files
 pecos.io.write_test_results(pm.test_results)
 pecos.io.write_monitoring_report(pm.df, pm.test_results, test_results_graphics, 
-                                 ['custom.png'], title='System1 2015 Performance Metrics')
+                                 ['custom.png'], title='System1 2015')

--- a/examples/pv/pv_model.py
+++ b/examples/pv/pv_model.py
@@ -3,86 +3,93 @@ import pvlib
 import pandas as pd
 import numpy as np
 
-def sapm(pm, poa, wind, temp, sapm_parameters, location):
+def sapm(pm, sapm_parameters, location):
+    """
+    Run the SAPM and compute metrics. Remove data points that failed a previous 
+    quality control test before running the model (using pm.cleaned_data). Check range 
+    on DC power relative error and normalized efficiency. Compute PV metrics.  
+    """
+    index = pm.cleaned_data.index
     
-    # pvlib expects Pandas series
-    if type(wind) is pd.core.frame.DataFrame:
-        wind = pd.Series(wind.values[:,0], index=wind.index)
-    if type(temp) is pd.core.frame.DataFrame:
-        temp = pd.Series(temp.values[:,0], index=temp.index)
-    if type(poa) is pd.core.frame.DataFrame:
-        poa = pd.Series(poa.values[:,0], index=poa.index)
-    poa_diffuse = pd.Series(data=0, index=poa.index)
-         
-    index = poa.index  
-        
-    # Copute sun position
-    solarposition = pvlib.solarposition.ephemeris(index, location['Latitude'], location['Longitude'])
+    # Extract data into Pandas series
+    dcpower = pm.cleaned_data[pm.trans['DC Power']].sum(axis=1)
+    acpower = pm.cleaned_data[pm.trans['AC Power']].sum(axis=1)
+    wind = pm.cleaned_data[pm.trans['Wind Speed']].squeeze()
+    temperature = pm.cleaned_data[pm.trans['Ambient Temperature']].squeeze()
+    poa = pm.cleaned_data[pm.trans['POA']].squeeze()
+    poa_diffuse = pd.Series(data=0, index=index)
+    dni = pm.cleaned_data[pm.trans['DNI']].squeeze()
+    
+    # Compute sun position
+    solarposition = pvlib.solarposition.get_solarposition(index, location['Latitude'], 
+                                                  location['Longitude'])
     
     # Compute cell temperature
-    celltemp = pvlib.pvsystem.sapm_celltemp(poa, wind, temp)
+    celltemp = pvlib.pvsystem.sapm_celltemp(poa, wind, temperature)
 
-    # Compute alsolute airmass
-    airmass_relative  = pvlib.atmosphere.relativeairmass(solarposition['zenith'])
-    airmass_absolute = pvlib.atmosphere.absoluteairmass(airmass_relative)
+    # Compute absolute airmass
+    airmass_relative  = pvlib.atmosphere.get_relative_airmass(solarposition['zenith'])
+    airmass_absolute = pvlib.atmosphere.get_absolute_airmass(airmass_relative)
     
     # Compute aoi
-    aoi = pvlib.irradiance.aoi(location['Latitude'], 180, solarposition['zenith'], solarposition['azimuth'])
-           
-    Ee = pvlib.pvsystem.sapm_effective_irradiance(poa, poa_diffuse, airmass_absolute, aoi, sapm_parameters)
+    aoi = pvlib.irradiance.aoi(location['Latitude'], 180, solarposition['zenith'], 
+                               solarposition['azimuth'])
+    
+    # Compute effective irradiance
+    Ee = pvlib.pvsystem.sapm_effective_irradiance(poa, poa_diffuse, airmass_absolute, 
+                                                  aoi, sapm_parameters)
+    
+    # Run SAPM
     sapm_model = pvlib.pvsystem.sapm(Ee, celltemp['temp_cell'], sapm_parameters)
     
     # Compute the relative error between observed and predicted DC Power.  
     # Add the composite signal and run a range test
     modeled_dcpower = sapm_model['p_mp']*sapm_parameters['Ns']*sapm_parameters['Np']
-    modeled_dcpower = modeled_dcpower.to_frame('Expected DC Power')
-    pm.add_dataframe(modeled_dcpower)
-    
-    observed_dcpower = pm.df[pm.trans['DC Power']].sum(axis=1)
-    dc_power_relative_error = (np.abs(observed_dcpower - pm.df['Expected DC Power']))/observed_dcpower
-    dc_power_relative_error = dc_power_relative_error.to_frame('DC Power Relative Error')
-    pm.add_dataframe(dc_power_relative_error)
-    
+    dc_power_relative_error = np.abs(dcpower - modeled_dcpower)/dcpower
+    pm.add_dataframe(dc_power_relative_error.to_frame('DC Power Relative Error'))
     pm.check_range([0,0.1], 'DC Power Relative Error') 
     
     # Compute normalized efficiency, add the composite signal, and run a range test
-    P_ref = sapm_parameters['Vmpo']*sapm_parameters['Impo']*sapm_parameters['Ns']*sapm_parameters['Np'] # DC Power rating
-    NE = pecos.pv.normalized_efficiency(observed_dcpower, pm.df[pm.trans['POA']], P_ref)
-    pm.add_dataframe(NE)
-    pm.add_translation_dictionary({'Normalized Efficiency': list(NE.columns)})
+    P_ref = sapm_parameters['Vmpo']*sapm_parameters['Impo']* \
+                sapm_parameters['Ns']*sapm_parameters['Np'] # DC Power rating
+    NE = pecos.pv.normalized_efficiency(dcpower, poa, P_ref)
+    pm.add_dataframe(NE.to_frame('Normalized Efficiency'))
     pm.check_range([0.8, 1.2], 'Normalized Efficiency') 
     
     # Compute energy
-    energy = pecos.pv.energy(pm.df[pm.trans['AC Power']], tfilter=pm.tfilter)
-    total_energy = energy.sum(axis=1)
-    
+    energy = pecos.pv.energy(acpower, tfilter=pm.tfilter)
+    energy = energy.values[0]
+
     # Compute insolation
-    poa_insolation = pecos.pv.insolation(pm.df[pm.trans['POA']], tfilter=pm.tfilter)
+    poa_insolation = pecos.pv.insolation(poa, tfilter=pm.tfilter)
+    poa_insolation = poa_insolation.values[0]
     
     # Compute performance ratio
-    PR = pecos.pv.performance_ratio(total_energy, poa_insolation, P_ref)
+    PR = pecos.pv.performance_ratio(energy, poa_insolation, P_ref)
     
     # Compute performance index
     predicted_energy = pecos.pv.energy(modeled_dcpower, tfilter=pm.tfilter)
-    PI = pecos.pv.performance_index(total_energy, predicted_energy)
+    predicted_energy = predicted_energy.values[0]
+    PI = pecos.pv.performance_index(energy, predicted_energy)
     
     # Compute clearness index
-    dni_insolation = pecos.pv.insolation(pm.df[pm.trans['DNI']], tfilter=pm.tfilter)
-    ea = pvlib.irradiance.extraradiation(pm.df.index.dayofyear)
-    ea = pd.DataFrame(index=pm.df.index, data=ea, columns=['ea'])
+    dni_insolation = pecos.pv.insolation(dni, tfilter=pm.tfilter)
+    dni_insolation = dni_insolation.values[0]
+    ea = pvlib.irradiance.extraradiation(index.dayofyear)
+    ea = pd.Series(index=index, data=ea)
     ea_insolation = pecos.pv.insolation(ea, tfilter=pm.tfilter)
+    ea_insolation = ea_insolation.values[0]
     Kt = pecos.pv.clearness_index(dni_insolation, ea_insolation)
     
     # Compute energy yield
-    energy_yield = pecos.pv.energy_yield(total_energy, P_ref)
+    energy_yield = pecos.pv.energy_yield(energy, P_ref)
     
     # Collect metrics for reporting
-    total_energy = total_energy/3600/1000 # convert Ws to kWh
-    poa_insolation = poa_insolation/3600/1000 # convert Ws to kWh
-    energy_yield = energy_yield/3600 # convert s to h
-    total_energy = total_energy.to_frame('Total Energy (kWh)')
-    poa_insolation.columns = ['POA Insolation (kWh/m2)']
-    energy_yield.columns = ['Energy Yield (kWh/kWp)']
-    metrics = pd.concat([PR, PI, Kt, total_energy, poa_insolation, energy_yield], axis=1)
+    metrics = {'Performance Ratio': PR, 
+               'Performance Index': PI,
+               'Clearness Index': Kt,
+               'Total Energy (kWh)': energy/3600/1000, # convert Ws to kWh
+               'POA Insolation (kWh/m2)': poa_insolation/3600/1000, # convert Ws to kWh
+               'Energy Yield (kWh/kWp)': energy_yield/3600} # convert s to h
     
     return metrics

--- a/examples/simple/simple_config.yml
+++ b/examples/simple/simple_config.yml
@@ -11,14 +11,14 @@ Composite Signals:
 
 Time Filter: "({CLOCK_TIME} > 3*3600) & ({CLOCK_TIME} < 21*3600)"
 
-Corrupt Values: [-999]
+Corrupt: [-999]
 
-Range Bounds:
+Range:
   B: [0, 1]
   Wave: [-1, 1]
   Wave Error: [None, 0.25]
  
-Increment Bounds:
+Increment:
   A: [0.0001, None]
   B: [0.0001, None]
   Wave: [0.0001, 0.6] 

--- a/examples/simple/simple_example.py
+++ b/examples/simple/simple_example.py
@@ -31,8 +31,9 @@ pm.add_translation_dictionary({'Wave': ['C','D']}) # group C and D
 pm.check_timestamp(900)
  
 # Generate a time filter to exclude data points early and late in the day
-clock_time = pm.get_clock_time()
-time_filter = (clock_time > 3*3600) & (clock_time < 21*3600)
+clock_time = pecos.utils.datetime_to_clocktime(pm.df.index)
+time_filter = pd.Series((clock_time > 3*3600) & (clock_time < 21*3600), 
+                        index=pm.df.index)
 pm.add_time_filter(time_filter)
 
 # Check for missing data
@@ -42,11 +43,11 @@ pm.check_missing()
 pm.check_corrupt([-999]) 
 
 # Add a composite signal which compares measurements to a model
-elapsed_time= pm.get_elapsed_time()
-wave_model = np.sin(10*(elapsed_time/86400))
-wave_model_abs_error = np.abs(np.subtract(pm.df[pm.trans['Wave']], wave_model))
-wave_model_abs_error.columns=['Wave Error C', 'Wave Error D']
-pm.add_dataframe(wave_model_abs_error)
+wave_model = np.array(np.sin(10*clock_time/86400))
+wave_measurments = pm.df[pm.trans['Wave']]
+wave_error = np.abs(wave_measurments.subtract(wave_model,axis=0))
+wave_error.columns=['Wave Error C', 'Wave Error D']
+pm.add_dataframe(wave_error)
 pm.add_translation_dictionary({'Wave Error': ['Wave Error C', 'Wave Error D']})
 
 # Check data for expected ranges

--- a/examples/simple/simple_example.py
+++ b/examples/simple/simple_example.py
@@ -22,7 +22,6 @@ pecos.logger.initialize()
 pm = pecos.monitoring.PerformanceMonitoring()
 
 # Populate the object with a DataFrame and translation dictionary
-system_name = 'Simple'
 data_file = 'simple.xlsx'
 df = pd.read_excel(data_file, index_col=0)
 pm.add_dataframe(df)
@@ -60,16 +59,16 @@ pm.check_increment([0.0001, None], 'A')
 pm.check_increment([0.0001, None], 'B') 
 pm.check_increment([0.0001, 0.6], 'Wave') 
     
-# Compute the quality control index
-QCI = pecos.metrics.qci(pm.mask, pm.tfilter)
+# Compute the quality control index for A, B, C, and D
+mask = pm.mask[['A','B','C','D']]
+QCI = pecos.metrics.qci(mask, pm.tfilter)
 
 # Generate graphics
 test_results_graphics = pecos.graphics.plot_test_results(pm.df, pm.test_results)
 df.plot(ylim=[-1.5,1.5], figsize=(7.0,3.5))
 plt.savefig('custom.png', format='png', dpi=500)
 
-# Write metrics, test results, and report files
-pecos.io.write_metrics(QCI)
+# Write test results and report files
 pecos.io.write_test_results(pm.test_results)
 pecos.io.write_monitoring_report(pm.df, pm.test_results, test_results_graphics, 
                                  ['custom.png'], QCI)

--- a/examples/simple/simple_example_using_config.py
+++ b/examples/simple/simple_example_using_config.py
@@ -10,67 +10,59 @@ import pecos
 # Initialize logger
 pecos.logger.initialize()
 
-# Open configuration file and extract information
+# Open configuration file
 config_file = 'simple_config.yml'
 fid = open(config_file, 'r')
 config = yaml.load(fid)
 fid.close()
-specs = config['Specifications']
-translation_dictionary = config['Translation']
-composite_signals = config['Composite Signals']
-time_filter = config['Time Filter']
-corrupt_values = config['Corrupt Values']
-range_bounds = config['Range Bounds']
-increment_bounds = config['Increment Bounds']
    
 # Create a Pecos PerformanceMonitoring data object
 pm = pecos.monitoring.PerformanceMonitoring()
 
 # Populate the object with a DataFrame and translation dictionary
-system_name = 'Simple'
 data_file = 'simple.xlsx'
 df = pd.read_excel(data_file, index_col=0)
 pm.add_dataframe(df)
-pm.add_translation_dictionary(translation_dictionary)
+pm.add_translation_dictionary(config['Translation'])
 
 # Check the expected frequency of the timestamp
-pm.check_timestamp(specs['Frequency'])
+pm.check_timestamp(config['Specifications']['Frequency'])
  
 # Generate a time filter to exclude data points early and late in the day
-time_filter = pm.evaluate_string('Time Filter', time_filter)
+time_filter = pm.evaluate_string('Time Filter', config['Time Filter'])
 pm.add_time_filter(time_filter)
 
 # Check for missing data
 pm.check_missing()
         
 # Check for corrupt data values
-pm.check_corrupt(corrupt_values) 
+pm.check_corrupt(config['Corrupt']) 
 
 # Add a composite signal which compares measurements to a model
-for composite_signal in composite_signals:
+for composite_signal in config['Composite Signals']:
     for key, value in composite_signal.items():
-        signal = pm.evaluate_string(key, value, specs)
+        signal = pm.evaluate_string(key, value, config['Specifications'])
         pm.add_dataframe(signal)
         pm.add_translation_dictionary({key: list(signal.columns)})
 
 # Check data for expected ranges
-for key,value in range_bounds.items():
+for key,value in config['Range'].items():
     pm.check_range(value, key)
 
 # Check data for stagnant and abrupt changes
-for key,value in increment_bounds.items():
+for key,value in config['Increment'].items():
     pm.check_increment(value, key) 
     
-# Compute the quality control index
-QCI = pecos.metrics.qci(pm.mask, pm.tfilter)
+# Compute the quality control index for A, B, C, and D
+mask = pm.mask[['A','B','C','D']]
+QCI = pecos.metrics.qci(mask, pm.tfilter)
 
 # Generate graphics
 test_results_graphics = pecos.graphics.plot_test_results(pm.df, pm.test_results)
 df.plot(ylim=[-1.5,1.5], figsize=(7.0,3.5))
 plt.savefig('custom.png', format='png', dpi=500)
 
-# Write metrics, test results, and report files
-pecos.io.write_metrics(QCI)
+# Write test results and report files
 pecos.io.write_test_results(pm.test_results)
 pecos.io.write_monitoring_report(pm.df, pm.test_results, test_results_graphics, 
                                  ['custom.png'], QCI)

--- a/pecos/graphics.py
+++ b/pecos/graphics.py
@@ -4,7 +4,10 @@ heatmap plots for reports.
 """
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except:
+    pass
 try:
     import plotly
 except:

--- a/pecos/graphics.py
+++ b/pecos/graphics.py
@@ -300,7 +300,7 @@ def plot_heatmap(data, colors=[(0.75, 0.15, 0.15), (1, 0.75, 0.15), (0.15, 0.75,
     
     Parameters
     -----------
-    data : pandas DataFrame or numpy ndarray
+    data : pandas DataFrame, pandas Series, or numpy array
         Data
     
     colors : list (optional)
@@ -326,9 +326,11 @@ def plot_heatmap(data, colors=[(0.75, 0.15, 0.15), (1, 0.75, 0.15), (0.15, 0.75,
     figsize : tuple (optional)
         Figure size, default = (5.0, 5.0)
     """
-    if type(data) is pd.core.frame.DataFrame:
+    if isinstance(data, (pd.DataFrame, pd.Series)):
             data = data.values
-            
+    if len(data.shape) == 1:
+        data = np.expand_dims(data, axis=0)
+        
     if not cmap:
         from matplotlib.colors import LinearSegmentedColormap
         cmap = LinearSegmentedColormap.from_list(name='custom', colors=colors, N=nColors)

--- a/pecos/io.py
+++ b/pecos/io.py
@@ -49,7 +49,8 @@ def read_campbell_scientific(filename, index_col='TIMESTAMP', encoding=None):
     
     Returns
     ---------
-    pandas DataFrame with data
+    pandas DataFrame
+        Data
     """
     logger.info("Reading Campbell Scientific CSV file " + filename)
 
@@ -158,7 +159,8 @@ def write_metrics(metrics, filename='metrics.csv'):
     
     Returns
     ------------
-    filename : string
+    string
+        filename
     """
     logger.info("Write metrics file")
 
@@ -196,7 +198,8 @@ def write_test_results(test_results, filename='test_results.csv'):
     
     Returns
     ------------
-    filename : string
+    string
+        filename
     """
 
     test_results.sort_values(list(test_results.columns), inplace=True)
@@ -266,7 +269,8 @@ def write_monitoring_report(data, test_results, test_results_graphics=[],
         
     Returns
     ------------
-    filename : string
+    string
+        filename
     """
     logger.info("Writing HTML report")
     
@@ -397,7 +401,8 @@ def write_dashboard(column_names, row_names, content, title='Pecos Dashboard',
     
     Returns
     ------------
-    filename : string
+    string
+        filename
     """
     
     logger.info("Writing dashboard")

--- a/pecos/io.py
+++ b/pecos/io.py
@@ -239,7 +239,7 @@ def write_monitoring_report(data, test_results, test_results_graphics=[],
     custom_graphics : list of strings (optional)
         Custom files, with full path.  Created by the user.
     
-    metrics : pandas DataFrame (optional)
+    metrics : pandas Series or DataFrame (optional)
         Performance metrics to add as a table to the monitoring report
     
     title : string (optional)
@@ -299,8 +299,12 @@ def write_monitoring_report(data, test_results, test_results_graphics=[],
     # Convert to html format
     if metrics is None:
         metrics = pd.DataFrame()
+    if isinstance(metrics, pd.Series):
+        metrics_html = metrics.to_frame().to_html(header=False)
+    if isinstance(metrics, pd.DataFrame):  
+        metrics_html = metrics.to_html(justify='left')
+        
     test_results_html = test_results.to_html(justify='left')
-    metrics_html = metrics.to_html(justify='left')
     notes_html = notes_df.to_html(justify='left', header=False)
     
     content = {'start_time': str(start_time), 

--- a/pecos/metrics.py
+++ b/pecos/metrics.py
@@ -4,22 +4,21 @@ analysis or compute quantities that might be of use in the analysis
 """
 import pandas as pd
 import numpy as np
-import datetime
 import logging
 
 logger = logging.getLogger(__name__)
 
-def qci(mask, tfilter=None, per_day=True):
+def qci(mask, tfilter=None):
     """
-    Compute the quality control index (QCI), defined as:
+    Compute the quality control index (QCI) for each column, defined as:
     
-    :math:`QCI=\dfrac{\sum_{d\in D}\sum_{t\in T}X_{dt}}{|DT|}`
+    :math:`QCI=\dfrac{\sum_{t\in T}X_{dt}}{|T|}`
     
     where 
-    :math:`D` is the set of data columns and 
     :math:`T` is the set of timestamps in the analysis.  
-    :math:`X_{dt}` is a data point for column :math:`d` time t` that passed all quality control test.  
-    :math:`|DT|` is the number of data points in the analysis.
+    :math:`X_{dt}` is a data point for column :math:`d` time t` that passed 
+    all quality control test.  
+    :math:`|T|` is the number of data points in the analysis.
     
     Parameters
     ----------
@@ -29,106 +28,73 @@ def qci(mask, tfilter=None, per_day=True):
     tfilter : pandas Series (optional)
         Time filter containing boolean values for each time index
         
-    per_day : boolean (optional)
-        Flag indicating if the results should be computed per day, default = True
-    
     Returns
     -------
-    pandas DataFrame with quality control index
+    pandas Series
+        Quality control index
     """
-    logger.info("Compute QCI")
     
-    # Remove time filter
     if tfilter is not None:
         mask = mask[tfilter]
-    
-    if per_day:     
-        dates = [mask.index[0].date() + datetime.timedelta(days=x) for x in range(0, (mask.index[-1].date()-mask.index[0].date()).days+1)]
-    
-        QCI = pd.DataFrame(index=pd.to_datetime(dates))
-    
-        for date in dates:
-            mask_date = mask.loc[date.strftime('%m/%d/%Y')]
-            try:
-                QCIndex = mask_date.sum().sum()/float(mask_date.shape[0]*mask_date.shape[1])
-                if np.isnan(QCIndex):
-                    QCIndex = 0
-                QCI.loc[date, 'Quality Control Index'] = QCIndex
-            except:
-                QCI.loc[date, 'Quality Control Index'] = 0
-    else:
-        QCI = mask.sum().sum()/float(mask.shape[0]*mask.shape[1])
-        
-    return QCI   
 
-def rmse(x1, x2, tfilter=None, per_day=True):
+    qci = mask.sum()/mask.shape[0]
+        
+    return qci   
+
+def rmse(data1, data2, tfilter=None):
     """
-    Compute the root mean squared error (RMSE), defined as:
+    Compute the root mean squared error (RMSE) for each column, defined as:
     
-    :math:`RMSE=\sqrt{\dfrac{\sum{(x_1-x_2)^2}}{n}}`
+    :math:`RMSE=\sqrt{\dfrac{\sum{(data_1-data_2)^2}}{n}}`
     
     where
-    :math:`x_1` is a time series,
-    :math:`x_2` is a time series, and 
+    :math:`data_1` is a time series,
+    :math:`data_2` is a time series, and 
     :math:`n` is a number of data points.
     
     Parameters
     -----------
-    x1 : pandas DataFrame with a single column or pandas Series
+    data1 : pandas DataFrame
         Data
         
-    x2 : pandas DataFrame with a single column or pandas Series
-        Data
+    data2 : pandas DataFrame
+        Data. Note, the column names in data1 must equal the column names in data2
          
     tfilter : pandas Series (optional)
         Time filter containing boolean values for each time index
         
-    per_day : boolean (optional)
-        Flag indicating if the results should be computed per day, default = True
-    
     Returns
     -------
-    pandas DataFrame with root mean squared error
+    pandas Series
+        Root mean squared error
     """
-    logger.info("Compute RMSE")
     
-    if type(x1) is pd.core.frame.DataFrame:
-        x1 = pd.Series(x1.values[:,0], index=x1.index)
-    if type(x2) is pd.core.frame.DataFrame:
-        x2 = pd.Series(x2.values[:,0], index=x2.index)
-        
+    if len(set(data1.columns).symmetric_difference(set(data2.columns))) > 0:
+        logger.warning("The column names in 'data1' must equal the column names in 'data2'")
+        return
+    
     if tfilter is not None:
-        x1 = x1[tfilter]
-        x2 = x2[tfilter]
-        
-    def compute_rmse(data1, data2):
-        val = np.sqrt(np.mean(np.power(data1 - data2,2)))
-        return val
-        
-    if per_day:
-        dates = [x1.index[0].date() + datetime.timedelta(days=x) for x in range(0, (x1.index[-1].date()-x1.index[0].date()).days+1)]
-        rmse = pd.DataFrame(index=pd.to_datetime(dates))
-        for date in dates:
-            x1_date1 = x1.loc[date.strftime('%m/%d/%Y')] 
-            x2_date2 = x2.loc[date.strftime('%m/%d/%Y')] 
-            val = compute_rmse(x1_date1, x2_date2)
-            rmse.loc[date, 'RMSE'] = val
-    else:
-        val = compute_rmse(x1, x2)
-        rmse = pd.DataFrame(val, index=[0], columns=['RMSE'])
+        data1 = data1[tfilter]
+        data2 = data2[tfilter]
+    
+    rmse = {}
+    for col in data1.columns:
+        rmse[col] = np.sqrt(np.mean(np.power(data1[col] - data2[col],2)))
+    
+    rmse = pd.Series(rmse)
 
     return rmse
     
-def time_integral(data, tfilter=None, per_day=True):
+def time_integral(data, tfilter=None):
     """
-    Compute the time integral (F) of each column in the DataFrame, defined as:
+    Compute the time integral (F) for each column, defined as:
     
     :math:`F=\int{fdt}`
     
     where 
     :math:`f` is a column of data 
     :math:`dt` is the time step between observations.
-    The time integral is computed using the trapezoidal rule from numpy.trapz.
+    The integral is computed using the trapezoidal rule from numpy.trapz.
     Results are given in [original data units]*seconds.
     NaN values are set to 0 for integration.
     
@@ -140,45 +106,72 @@ def time_integral(data, tfilter=None, per_day=True):
     tfilter : pandas Series (optional)
         Time filter containing boolean values for each time index
         
-    per_day : boolean (doptional)
-        Flag indicating if the results should be computed per day, default = True
-    
     Returns
     -------
-    pandas DataFrame with time integral of the data, each column is named 
-    'Time integral of ' + original column name
+    pandas Series
+        Integral
     """
-    logger.info("Compute time integral")
     
+    if isinstance(data, pd.Series):
+        data = data.to_frame()
+        
     if tfilter is not None:
         data = data[tfilter]
     
     data = data.fillna(0) # fill NaN with 0
     
-    def compute_integral(d):
-        val = {}
-        tdelta = ((d.index - d.index[0]).values)/1000000000 # convert ns to seconds
-        for col in d.columns:
-            val['Time integral of ' + col] = float(np.trapz(d.loc[:,col], tdelta))
-        return val
-        
-    if per_day:
-        dates = [data.index[0].date() + datetime.timedelta(days=x) for x in range(0, (data.index[-1].date()-data.index[0].date()).days+1)]
-        F = pd.DataFrame(index=pd.to_datetime(dates))
-        for date in dates:
-            df_date = data.loc[date.strftime('%m/%d/%Y')] 
-            df_int = compute_integral(df_date)
-            for col in df_int:
-                F.loc[date, col] = df_int[col]
-    else:
-        F = compute_integral(data)
-        F = pd.DataFrame(F, index=[0])
+    tdelta = (data.index - data.index[0]).total_seconds() # convert to seconds
     
+    F = {}
+    for col in data.columns:
+        F[col] = float(np.trapz(data.loc[:,col], tdelta))
+    
+    F = pd.Series(F)
+        
     return F
+
+def time_derivative(data, tfilter=None):
+    """
+    Compute the derivative (f') of each column, defined as:
+    
+    :math:`f'=\dfrac{df}{dt}`
+    
+    where 
+    :math:`f` is a column of data 
+    :math:`dt` is the time step between observations.
+    The derivative is computed using central differences from numpy.gradient.
+    Results are given in [original data units]/seconds.
+    
+    Parameters
+    -----------
+    data : pandas DataFrame
+        Data
+         
+    tfilter : pandas Series (optional)
+        Filter containing boolean values for each time index
+        
+    Returns
+    -------
+    pandas DataFrame
+        Derivative of the data
+    """
+    
+    if tfilter is not None:
+        data = data[tfilter]
+    
+    tdelta = (data.index - data.index[0]).total_seconds() # convert to seconds
+    
+    f = {}
+    for col in data.columns:
+        f[col] = np.gradient(data.loc[:,col], tdelta)
+    
+    f = pd.DataFrame(f, index=data.index)
+    
+    return f
 
 def probability_of_detection(observed, actual, tfilter=None):
     """ 
-    Compute probability of detection (PD), defined as:
+    Compute probability of detection (PD) for each column, defined as:
         
     :math:`PD=\dfrac{TP}{TP+FN}`
     
@@ -189,39 +182,54 @@ def probability_of_detection(observed, actual, tfilter=None):
     Parameters
     ----------
     observed : pandas DataFrame
-        Estimated conditions (True = background, False = anomolous), 
+        Estimated conditions (True = background, False = anomalous), 
         returned from pm.mask
     
     actual : pandas DataFrame
-        Actual conditions, (True = background, False = anomolous)
-   
+        Actual conditions, (True = background, False = anomalous).
+        Note, the column names in observed must equal the column names in actual
+    
+    tfilter : pandas Series (optional)
+        Filter containing boolean values for each time index
+        
     Returns
     -------
-    Probability of detection, float
+    pandas Series
+        Probability of detection
     """
-    # Remove time filter
+    
+    if len(set(observed.columns).symmetric_difference(set(actual.columns))) > 0:
+        logger.warning("The column names in 'observed' must equal the column names in 'actual'")
+        return
+    
     if tfilter is not None:
         observed = observed[tfilter]
         actual = actual[tfilter]
 
-    # True positive (TP) = anomolous condition where tests fail
-    # TP is 1 where the statement is true, Nan where the statement is false
-    TP = (observed.where(observed == False)+1) == (actual.where(actual == False)+1)
-    TP_count = TP.sum().sum()
+    PD = {}
+    for col in observed.columns:
+        obs = observed[col]
+        act = actual[col]
+        
+        # True positive (TP) = anomalous condition where tests fail
+        # TP is 1 where the statement is true, Nan where the statement is false
+        TP = (obs.where(obs == False)+1) == (act.where(act == False)+1)
+        TP_count = TP.sum()
     
-    # False negative (FN) = anomolous condition where tests pass
-    # FN is 1 where the statement is true, Nan where the statement is false
-    FN = (observed.where(observed == True)) == (actual.where(actual == False)+1)
-    FN_count = FN.sum().sum()
+        # False negative (FN) = anomalous condition where tests pass
+        # FN is 1 where the statement is true, Nan where the statement is false
+        FN = (obs.where(obs == True)) == (act.where(act == False)+1)
+        FN_count = FN.sum()                            
+                              
+        PD[col] = TP_count/float(TP_count+FN_count)
     
-    # Probability of detection
-    PD = TP_count/float(TP_count+FN_count)
+    PD = pd.Series(PD)
     
     return PD
 
 def false_alarm_rate(observed, actual, tfilter=None):
     """ 
-    Compute false alarm rate (FAR), defined as:
+    Compute false alarm rate (FAR) for each column, defined as:
         
     :math:`FAR=\dfrac{TN}{TN+FP}`
     
@@ -232,32 +240,48 @@ def false_alarm_rate(observed, actual, tfilter=None):
     Parameters
     ----------
     estimated : pandas DataFrame
-        Estimated conditions (True = background, False = anomolous), 
+        Estimated conditions (True = background, False = anomalous), 
         returned from pm.mask
     
     actual : pandas DataFrame
-        Actual conditions, (True = background, False = anomolous)
+        Actual conditions, (True = background, False = anomalous).
+        Note, the column names in observed must equal the column names in actual.
     
+    tfilter : pandas Series (optional)
+        Filter containing boolean values for each time index
+        
     Returns
     -------
-    False alarm rate, float
+    pandas Series
+        False alarm rate (FAR)
     """
+    
+    if len(set(observed.columns).symmetric_difference(set(actual.columns))) > 0:
+        logger.warning("The column names in 'observed' must equal the column names in 'actual'")
+        return
+    
     # Remove time filter
     if tfilter is not None:
         observed = observed[tfilter]
         actual = actual[tfilter]
 
-    # True negative (TN) = normal condition where tests pass
-    # TN is 1 where the statement is true, Nan where the statement is false
-    TN = (observed.where(observed == True)) == (actual.where(actual == True))
-    TN_count = TN.sum().sum()
+    FAR = {}
+    for col in observed.columns:
+        obs = observed[col]
+        act = actual[col]
+        
+        # True negative (TN) = normal condition where tests pass
+        # TN is 1 where the statement is true, Nan where the statement is false
+        TN = (obs.where(obs == True)) == (act.where(act == True))
+        TN_count = TN.sum()
+        
+        # False positive (FP) = normal condition where tests fail
+        # FP is 1 where the statement is true, Nan where the statement is false
+        FP = (obs.where(obs == False)+1) == (act.where(act == True))
+        FP_count = FP.sum()                                
+                      
+        FAR[col] = 1-TN_count/float(TN_count+FP_count)
     
-    # False positive (FP) = normal condition where tests fail
-    # FP is 1 where the statement is true, Nan where the statement is false
-    FP = (observed.where(observed == False)+1) == (actual.where(actual == True))
-    FP_count = FP.sum().sum()
-    
-    # False alarm rate
-    FAR = 1-TN_count/float(TN_count+FP_count)
+    FAR = pd.Series(FAR)
     
     return FAR

--- a/pecos/metrics.py
+++ b/pecos/metrics.py
@@ -253,7 +253,7 @@ def false_alarm_rate(observed, actual, tfilter=None):
     Returns
     -------
     pandas Series
-        False alarm rate (FAR)
+        False alarm rate
     """
     
     if len(set(observed.columns).symmetric_difference(set(actual.columns))) > 0:

--- a/pecos/monitoring.py
+++ b/pecos/monitoring.py
@@ -28,11 +28,12 @@ def _documented_by(original):
         """
         new_docstring = docstring.replace(old, new) + \
         """   
-                Returns    
-                ----------
-                Dictionary
-                    Results include cleaned data, mask, and test results summary
+        Returns    
+        ----------
+        dictionary
+            Results include cleaned data, mask, and test results summary
         """
+
         target.__doc__ = new_docstring
         return target
     return wrapper

--- a/pecos/pv.py
+++ b/pecos/pv.py
@@ -19,7 +19,7 @@ def insolation(G, tfilter=None):
     The time integral is computed using the trapezoidal rule.
     Results are given in [irradiance units]*seconds.
     
-     Parameters
+    Parameters
     -----------
     G : pandas DataFrame
         Irradiance time series

--- a/pecos/pv.py
+++ b/pecos/pv.py
@@ -7,7 +7,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def insolation(G, tfilter=None, per_day=True):
+def insolation(G, tfilter=None):
     """
     Compute insolation defined as:
     
@@ -27,21 +27,17 @@ def insolation(G, tfilter=None, per_day=True):
     tfilter : pandas Series (optional)
         Time filter containing boolean values for each time index
         
-    per_day : boolean (optional)
-        Flag indicating if the results should be computed per day, default = True
-    
     Returns
     -------
-    Insolation in a pandas DataFrame
+    pandas Series
+        Insolation
     """
-    if type(G) is pd.core.series.Series:
-        G = G.to_frame('Irradiance')
-        
-    H = time_integral(G,  tfilter=tfilter, per_day=per_day)
     
+    H = time_integral(G, tfilter=tfilter)
+
     return H
     
-def energy(P, tfilter=None, per_day=True):
+def energy(P, tfilter=None):
     """
     Convert energy defined as:
     
@@ -61,17 +57,13 @@ def energy(P, tfilter=None, per_day=True):
     tfilter : pandas Series (optional)
         Time filter containing boolean values for each time index
         
-    per_day : boolean (optional)
-        Flag indicating if the results should be computed per day, default = True
-    
     Returns
     -------
-    Energy in a pandas DataFrame 
+    pandas Series
+        Energy
     """
-    if type(P) is pd.core.series.Series:
-        P = P.to_frame('Power')
-        
-    E = time_integral(P, tfilter=tfilter, per_day=per_day)
+    
+    E = time_integral(P, tfilter=tfilter)
     
     return E
 
@@ -89,10 +81,10 @@ def performance_ratio(E, H_poa, P_ref, G_ref=1000):
     
     Parameters
     -----------
-    E : pandas DataFrame with a single column or pandas Series
+    E : pandas Series or float
         Energy (AC or DC) 
         
-    H_poa : pandas DataFrame with a single column or pandas Series
+    H_poa : pandas Series or float
          Plane of array insolation
          
     P_ref : float
@@ -103,20 +95,14 @@ def performance_ratio(E, H_poa, P_ref, G_ref=1000):
         
     Returns
     -------
-    Performance ratio in a pandas DataFrame
+    pandas Series or float
+        Performance ratio in a pandas Series (if E or H_poa are Series) or 
+        float (if E and H_poa are floats) 
     """
-    logger.info("Compute Performance Ratio")
     
-    if type(E) is pd.core.frame.DataFrame:
-        E = pd.Series(E.values[:,0], index=E.index)
-    if type(H_poa) is pd.core.frame.DataFrame:
-        H_poa = pd.Series(H_poa.values[:,0], index=H_poa.index)
-        
     Yf = E/P_ref
     Yr = H_poa/G_ref
     PR = Yf/Yr
-    
-    PR = PR.to_frame('Performance Ratio')
     
     return PR
 
@@ -134,10 +120,10 @@ def normalized_current(I, G_poa, I_sco, G_ref=1000):
     
     Parameters
     -----------
-    I : pandas DataFrame with a single column or pandas Series
+    I : pandas Series or float
         Current
         
-    G_poa : pandas DataFrame with a single column or pandas Series
+    G_poa : pandas Series or float
          Plane of array irradiance
          
     I_sco : float
@@ -148,20 +134,14 @@ def normalized_current(I, G_poa, I_sco, G_ref=1000):
         
     Returns
     -------
-    Normalized current in a pandas DataFrame
+    pandas Series or float
+        Normalized current in a pandas Series (if I or G_poa are Series) or 
+        float (if I and G_poa are floats) 
     """
-    logger.info("Compute Normalized Current")
     
-    if type(I) is pd.core.frame.DataFrame:
-        I = pd.Series(I.values[:,0], index=I.index)
-    if type(G_poa) is pd.core.frame.DataFrame:
-        G_poa = pd.Series(G_poa.values[:,0], index=G_poa.index)
-        
     N = I/I_sco
     D = G_poa/G_ref
     NI = N/D
-    
-    NI = NI.to_frame('Normalized Current')
     
     return NI
     
@@ -179,10 +159,10 @@ def normalized_efficiency(P, G_poa, P_ref, G_ref=1000):
     
     Parameters
     -----------
-    P : pandas DataFrame with a single column or pandas Series
+    P : pandas Series or float
         Power (AC or DC) 
         
-    G_poa : pandas DataFrame with a single column or pandas Series
+    G_poa : pandas Series or float
          Plane of array irradiance
          
     P_ref : float
@@ -193,20 +173,14 @@ def normalized_efficiency(P, G_poa, P_ref, G_ref=1000):
         
     Returns
     -------
-    Normalized efficiency in a pandas DataFrame
+    pandas Series or float
+        Normalized efficiency in a pandas Series (if P or G_poa are Series) or 
+        float (if P and G_poa are floats) 
     """
-    logger.info("Compute Normalized Efficiency")
     
-    if type(P) is pd.core.frame.DataFrame:
-        P = pd.Series(P.values[:,0], index=P.index)
-    if type(G_poa) is pd.core.frame.DataFrame:
-        G_poa = pd.Series(G_poa.values[:,0], index=G_poa.index)
-        
     Yf = P/P_ref
     Yr = G_poa/G_ref
     NE = Yf/Yr
-    
-    NE = NE.to_frame('Normalized Efficiency')
     
     return NE
     
@@ -228,26 +202,20 @@ def performance_index(E, E_predicted):
     
     Parameters
     -----------
-    E : pandas DataFrame with a single column or pandas Series
+    E : pandas Series or float
         Observed energy
     
-    E_predicted : pandas DataFrame with a single column or pandas Series
+    E_predicted : pandas Series or float
         Predicted energy
         
     Returns
     ---------
-    Performance index in a pandas DataFrame
+    pandas Series or float
+        Performance index in a pandas Series (if E or E_predicted are Series) or 
+        float (if E and E_predicted are floats) 
     """
-    logger.info("Compute Performance Index")
-    
-    if type(E) is pd.core.frame.DataFrame:
-        E = pd.Series(E.values[:,0], index=E.index)
-    if type(E_predicted) is pd.core.frame.DataFrame:
-        E_predicted = pd.Series(E_predicted.values[:,0], index=E_predicted.index)
         
     PI = E/E_predicted
-    
-    PI = PI.to_frame('Performance Index')
     
     return PI
 
@@ -263,7 +231,7 @@ def energy_yield(E, P_ref):
     
     Parameters
     -----------
-    E : pandas DataFrame with a single column or pandas Series
+    E : pandas Series or float
         Observed energy
     
     P_ref : float
@@ -271,16 +239,11 @@ def energy_yield(E, P_ref):
         
     Returns
     ---------
-    Energy yield in a pandas DataFrame
+    pandas Series or float
+        Energy yield
     """
-    logger.info("Compute Energy Yield")
-    
-    if type(E) is pd.core.frame.DataFrame:
-        E = pd.Series(E.values[:,0], index=E.index)
 
     EY = E/P_ref
-    
-    EY = EY.to_frame('Energy Yield')
     
     return EY
     
@@ -299,25 +262,19 @@ def clearness_index(H_dn, H_ea):
     
     Parameters
     -----------
-    H_dn : pandas DataFrame with a single column or pandas Series
+    H_dn : pandas Series or float
         Direct normal insolation
     
-    H_ea : pandas DataFrame with a single column or pandas Series
+    H_ea : pandas Series or float
         Extraterrestrial insolation
         
     Returns
     -------
-    Clearness index in a pandas DataFrame
+    pandas Series or float
+        Clearness index in a pandas Series (if H_dn or H_ea are Series) or 
+        float (if H_dn and H_ea are floats) 
     """
-    logger.info("Compute Clearness Index")
-    
-    if type(H_dn) is pd.core.frame.DataFrame:
-        H_dn = pd.Series(H_dn.values[:,0], index=H_dn.index)
-    if type(H_ea) is pd.core.frame.DataFrame:
-        H_ea = pd.Series(H_ea.values[:,0], index=H_ea.index)
         
     Kt = H_dn/H_ea
-        
-    Kt = Kt.to_frame('Clearness Index')
     
     return Kt

--- a/pecos/tests/test_metrics.py
+++ b/pecos/tests/test_metrics.py
@@ -26,13 +26,13 @@ def test_pd_far():
     prob_detection = pecos.metrics.probability_of_detection(obser, actual)
     false_alarm = pecos.metrics.false_alarm_rate(obser, actual)
     
-    assert_almost_equal(prob_detection['A'], 0/1, 5)
-    assert_almost_equal(prob_detection['B'], 2/3, 5)
-    assert_almost_equal(prob_detection['C'], 1/2, 5)
+    assert_almost_equal(prob_detection['A'], 0/1.0, 5)
+    assert_almost_equal(prob_detection['B'], 2/3.0, 5)
+    assert_almost_equal(prob_detection['C'], 1/2.0, 5)
     
-    assert_almost_equal(false_alarm['A'], 1-3/3, 5)
-    assert_almost_equal(false_alarm['B'], 1-0/1, 5)
-    assert_almost_equal(false_alarm['C'], 1-1/2, 5)
+    assert_almost_equal(false_alarm['A'], 1-3/3.0, 5)
+    assert_almost_equal(false_alarm['B'], 1-0/1.0, 5)
+    assert_almost_equal(false_alarm['C'], 1-1/2.0, 5)
     
 def test_integral():
     periods = 5
@@ -65,11 +65,11 @@ def test_derivative():
 
     derivative = pecos.metrics.time_derivative(df)
 
-    expected = np.array([[3/3600, 2/3600, 0], 
-                         [3/3600, 2/3600, np.nan], 
-                         [0, 2/3600, 1/7200], 
-                         [-3/3600, 1.25/3600, np.nan],
-                         [-3/3600, 0.5/3600, 2/3600]])
+    expected = np.array([[3.0/3600, 2.0/3600, 0], 
+                         [3.0/3600, 2.0/3600, np.nan], 
+                         [0, 2.0/3600, 1.0/7200], 
+                         [-3.0/3600, 1.25/3600, np.nan],
+                         [-3.0/3600, 0.5/3600, 2.0/3600]])
     expected = pd.DataFrame(data=expected, index=index, columns=['A', 'B', 'C'])
 
     assert_frame_equal(expected, derivative)
@@ -81,10 +81,10 @@ def test_derivative():
 
     derivative = pecos.metrics.time_derivative(df)
 
-    expected = np.array([[3/3600, 2/3600, 0], 
-                         [3/3600, 2/3600, np.nan], 
-                         [1/3600, 1.75/3600, np.nan],
-                         [-3/3600, 1.25/3600, np.nan]])
+    expected = np.array([[3.0/3600, 2.0/3600, 0], 
+                         [3.0/3600, 2.0/3600, np.nan], 
+                         [1.0/3600, 1.75/3600, np.nan],
+                         [-3.0/3600, 1.25/3600, np.nan]])
     expected = pd.DataFrame(data=expected, index=index, columns=['A', 'B', 'C'])
 
     assert_frame_equal(expected, derivative)
@@ -163,4 +163,4 @@ def test_rmse():
     assert_almost_equal(RMSE['Power'], 2.8667, 4)
 
 if __name__ == '__main__':
-    test_integral()
+    test_derivative()

--- a/pecos/tests/test_metrics.py
+++ b/pecos/tests/test_metrics.py
@@ -1,4 +1,5 @@
 from nose.tools import *
+from pandas.util.testing import assert_frame_equal
 from os.path import abspath, dirname, join
 import pecos
 import numpy as np
@@ -25,20 +26,68 @@ def test_pd_far():
     prob_detection = pecos.metrics.probability_of_detection(obser, actual)
     false_alarm = pecos.metrics.false_alarm_rate(obser, actual)
     
-    assert_almost_equal(prob_detection, 3/6.0, 5)
-    assert_almost_equal(false_alarm, 2/6.0, 5)
+    assert_almost_equal(prob_detection['A'], 0/1, 5)
+    assert_almost_equal(prob_detection['B'], 2/3, 5)
+    assert_almost_equal(prob_detection['C'], 1/2, 5)
     
-def test_time_integral():
+    assert_almost_equal(false_alarm['A'], 1-3/3, 5)
+    assert_almost_equal(false_alarm['B'], 1-0/1, 5)
+    assert_almost_equal(false_alarm['C'], 1-1/2, 5)
+    
+def test_integral():
     periods = 5
     index = pd.date_range('1/1/2016', periods=periods, freq='H')
-    data = np.array([[1,2,3], [4,5,6], [7,8,9], [10,11,12], [13,14,15]])
+    data = np.array([[1,2,3], [4,4,3], [7,6,np.nan], [4,8,4], [1,8.5,6]])
     df = pd.DataFrame(data=data, index=index, columns=['A', 'B', 'C'])
     
-    df_integral = pecos.metrics.time_integral(df)
+    integral = pecos.metrics.time_integral(df)
+    print(integral)
+    assert_equal(integral['A'], 57600)
+    assert_equal(integral['B'], 83700)
+    assert_equal(integral['C'], 41400)
+
+    # test with irregular timesteps
+    index = index[[0,1,3,4]]
+    data = data[[0,1,3,4]]
+    df = pd.DataFrame(data=data, index=index, columns=['A', 'B', 'C'])
+
+    integral = pecos.metrics.time_integral(df)
+
+    assert_equal(integral['A'], 46800)
+    assert_equal(integral['B'], 83700)
+    assert_equal(integral['C'], 54000)
     
-    assert_equal(df_integral['Time integral of A'].values[0], 100800)
-    assert_equal(df_integral['Time integral of B'].values[0], 115200)
-    assert_equal(df_integral['Time integral of C'].values[0], 129600)
+def test_derivative():
+    periods = 5
+    index = pd.date_range('1/1/2016', periods=periods, freq='H')
+    data = np.array([[1,2,3], [4,4,3], [7,6,np.nan], [4,8,4], [1,8.5,6]])
+    df = pd.DataFrame(data=data, index=index, columns=['A', 'B', 'C'])
+
+    derivative = pecos.metrics.time_derivative(df)
+
+    expected = np.array([[3/3600, 2/3600, 0], 
+                         [3/3600, 2/3600, np.nan], 
+                         [0, 2/3600, 1/7200], 
+                         [-3/3600, 1.25/3600, np.nan],
+                         [-3/3600, 0.5/3600, 2/3600]])
+    expected = pd.DataFrame(data=expected, index=index, columns=['A', 'B', 'C'])
+
+    assert_frame_equal(expected, derivative)
+
+    # test with irregular timesteps
+    index = index[[0,1,2,4]]
+    data = data[[0,1,2,4]]
+    df = pd.DataFrame(data=data, index=index, columns=['A', 'B', 'C'])
+
+    derivative = pecos.metrics.time_derivative(df)
+
+    expected = np.array([[3/3600, 2/3600, 0], 
+                         [3/3600, 2/3600, np.nan], 
+                         [1/3600, 1.75/3600, np.nan],
+                         [-3/3600, 1.25/3600, np.nan]])
+    expected = pd.DataFrame(data=expected, index=index, columns=['A', 'B', 'C'])
+
+    assert_frame_equal(expected, derivative)
     
 def test_qci_no_test_results():
     periods = 5
@@ -53,10 +102,12 @@ def test_qci_no_test_results():
     pm.add_translation_dictionary(trans)
     
     mask = pm.mask
-    QCI = pecos.metrics.qci(mask, per_day=False)
+    QCI = pecos.metrics.qci(mask)
     
     assert_equal(mask.any().any(), True)
-    assert_equal(QCI, 1)
+    assert_equal(QCI['A'], 1)
+    assert_equal(QCI['B'], 1)
+    assert_equal(QCI['C'], 1)
     
 def test_qci_with_test_results():
     periods = 5
@@ -86,63 +137,30 @@ def test_qci_with_test_results():
     'Error Flag': 'Error Flag'}
     pm.test_results = pm.test_results.append(pd.DataFrame(test_result, index=[2]))
     mask = pm.mask
-    QCI = pecos.metrics.qci(mask, per_day = False)
+    QCI = pecos.metrics.qci(mask)
     
     expected_mask = pd.DataFrame(data=[[False, False, True],[False, True, True],[False, True, True],[False, True, True],[False, True, True]], 
                                  index=pm.df.index, 
                                  columns=pm.df.columns)
     
     assert_equal((mask == expected_mask).any().any(), True)
-    assert_equal(QCI, (15-5)/15.0)
+    assert_equal(QCI.mean(), (15-5)/15.0)
 
     tfilter = pd.Series(data = [True, False, True, True, True], index=pm.df.index)
-    QCI_with_tfilter = pecos.metrics.qci(mask, tfilter = tfilter, per_day=False)
+    QCI_with_tfilter = pecos.metrics.qci(mask, tfilter = tfilter)
     
-    assert_equal(QCI_with_tfilter, (12-3)/12.0)
+    assert_equal(QCI_with_tfilter.mean(), (12-3)/12.0)
     
-def test_qci_perday():
-    periods = 48
-    np.random.seed(100)
-    index = pd.date_range('1/1/2016', periods=periods, freq='H')
-    data=np.sin(np.random.rand(3,1)*np.arange(0,periods,1))
-    df = pd.DataFrame(data=data.transpose(), index=index, columns=['A', 'B', 'C'])
-    trans = dict(zip(df.columns, [[col] for col in df.columns]))
-    
-    pm = pecos.monitoring.PerformanceMonitoring()
-    pm.add_dataframe(df)
-    pm.add_translation_dictionary(trans)
-    
-    test_result = {
-    'Variable Name': 'A', 
-    'Start Time': '2016-01-01 01:00:00', 
-    'End Time': '2016-01-01 04:00:00', 
-    'Timesteps': 4, 
-    'Error Flag': 'Error Flag'}
-    pm.test_results = pm.test_results.append(pd.DataFrame(test_result, index=[1]))
-    
-    test_result = {
-    'Variable Name': 'B', 
-    'Start Time': '2016-01-01 00:00:00', 
-    'End Time': '2016-01-01 00:00:00', 
-    'Timesteps': 1, 
-    'Error Flag': 'Error Flag'}
-    pm.test_results = pm.test_results.append(pd.DataFrame(test_result, index=[2]))
-    
-    mask = pm.mask
-    QCI = pecos.metrics.qci(mask, per_day = False)
-    assert_equal(QCI, (144-5)/144.0)
-    
-    QCI = pecos.metrics.qci(mask, per_day = True)
-    assert_equal(QCI['Quality Control Index'][0], (72-5)/72.0)
-    assert_equal(QCI['Quality Control Index'][1], 1.0)
-
 def test_rmse():
     
     periods = 5
     index = pd.date_range('1/1/2016', periods=periods, freq='H')
     x1 = pd.DataFrame(data=np.array([4, 4, 4.5, 2.7, 6]), index=index, columns=['Power'])
-    x2 = pd.DataFrame(data=np.array([5,10,4.5,3,4]), index=index, columns=['Expected Power'])
+    x2 = pd.DataFrame(data=np.array([5,10,4.5,3,4]), index=index, columns=['Power'])
     
     RMSE = pecos.metrics.rmse(x1, x2)
-    
-    assert_almost_equal(RMSE.iloc[0,0], 2.8667, 4)
+
+    assert_almost_equal(RMSE['Power'], 2.8667, 4)
+
+if __name__ == '__main__':
+    test_integral()

--- a/pecos/tests/test_monitoring.py
+++ b/pecos/tests/test_monitoring.py
@@ -69,8 +69,7 @@ def simple_example_run_analysis(df):
     # Compute metrics
     QCI = pecos.metrics.qci(pm.mask, pm.tfilter)
 
-    # Write metrics, test results, and report files
-    pecos.io.write_metrics(QCI)
+    # Write test results
     pecos.io.write_test_results(pm.test_results)
 
     return QCI
@@ -282,7 +281,7 @@ class Test_simple_example(unittest.TestCase):
 
         QCI = simple_example_run_analysis(df)
 
-        assert_almost_equal(QCI.iloc[0,0],0.852113,6)
+        assert_almost_equal(QCI.mean(),0.852113,6)
 
         actual = pd.read_csv('test_results.csv', index_col=0)
         # Convert back to datetime just so that they are in the same format
@@ -303,7 +302,7 @@ class Test_simple_example(unittest.TestCase):
 
         QCI = simple_example_run_analysis(df)
 
-        assert_almost_equal(QCI.iloc[0,0],0.852113,6)
+        assert_almost_equal(QCI.mean(),0.852113,6)
 
         actual = pd.read_csv('test_results.csv', index_col=0)
         expected = pd.read_csv(join(datadir,'Simple_test_results_with_timezone.csv'), index_col=0)

--- a/pecos/tests/test_pv.py
+++ b/pecos/tests/test_pv.py
@@ -1,5 +1,5 @@
 from nose.tools import *
-from pandas.util.testing import assert_frame_equal
+from pandas.util.testing import assert_frame_equal, assert_series_equal
 from os.path import abspath, dirname, join
 import pandas as pd
 import numpy as np
@@ -15,11 +15,11 @@ def test_insolation():
     data = np.array([[1,2,3], [4,5,6], [7,8,9], [10,11,12], [13,14,15]])
     df = pd.DataFrame(data=data, index=index, columns=['A', 'B', 'C'])
     
-    df_integral = pecos.pv.insolation(df)
+    integral = pecos.pv.insolation(df)
     
-    assert_equal(df_integral['Time integral of A'].values[0], 100800)
-    assert_equal(df_integral['Time integral of B'].values[0], 115200)
-    assert_equal(df_integral['Time integral of C'].values[0], 129600)
+    assert_equal(integral['A'], 100800)
+    assert_equal(integral['B'], 115200)
+    assert_equal(integral['C'], 129600)
 
 def test_energy():
     # same test as metrics.time_integral
@@ -28,73 +28,76 @@ def test_energy():
     data = np.array([[1,2,3], [4,5,6], [7,8,9], [10,11,12], [13,14,15]])
     df = pd.DataFrame(data=data, index=index, columns=['A', 'B', 'C'])
     
-    df_integral = pecos.pv.energy(df)
+    integral = pecos.pv.energy(df)
     
-    assert_equal(df_integral['Time integral of A'].values[0], 100800)
-    assert_equal(df_integral['Time integral of B'].values[0], 115200)
-    assert_equal(df_integral['Time integral of C'].values[0], 129600)
+    assert_equal(integral['A'], 100800)
+    assert_equal(integral['B'], 115200)
+    assert_equal(integral['C'], 129600)
     
 def test_performance_ratio():
     
     periods = 5
     index = pd.date_range('1/1/2016', periods=periods, freq='H')
-    E = pd.DataFrame(data=np.array([4, 4, 4.5, 2.7, 6]), index=index, columns=['Energy'])
-    POA = pd.DataFrame(data=np.array([1000,1250,1250,900,1500]), index=index, columns=['POA'])
+    E = pd.Series(data=np.array([4, 4, 4.5, 2.7, 6]), index=index)
+    POA = pd.Series(data=np.array([1000,1250,1250,900,1500]), index=index)
     
     PR = pecos.pv.performance_ratio(E, POA, 4, 1000)
-    expected = pd.DataFrame(data=np.array([1.0, 0.8, 0.9, 0.75, 1.0]), index=index, columns=['Performance Ratio'])
-    assert_frame_equal(PR, expected, check_dtype=False)
+    expected = pd.Series(data=np.array([1.0, 0.8, 0.9, 0.75, 1.0]), index=index)
+    assert_series_equal(PR, expected, check_dtype=False)
 
 def test_normalized_current():
     
     periods = 5
     index = pd.date_range('1/1/2016', periods=periods, freq='H')
-    I = pd.DataFrame(data=np.array([4, 4, 4.5, 2.7, 6]), index=index, columns=['Current'])
-    POA = pd.DataFrame(data=np.array([1000,1250,1250,900,1500]), index=index, columns=['POA'])
+    I = pd.Series(data=np.array([4, 4, 4.5, 2.7, 6]), index=index)
+    POA = pd.Series(data=np.array([1000,1250,1250,900,1500]), index=index)
     
     NI = pecos.pv.normalized_current(I, POA, 4, 1000)
-    expected = pd.DataFrame(data=np.array([1.0, 0.8, 0.9, 0.75, 1.0]), index=index, columns=['Normalized Current'])
-    assert_frame_equal(NI, expected, check_dtype=False)
+    expected = pd.Series(data=np.array([1.0, 0.8, 0.9, 0.75, 1.0]), index=index)
+    assert_series_equal(NI, expected, check_dtype=False)
     
 def test_normalized_efficiency():
     
     periods = 5
     index = pd.date_range('1/1/2016', periods=periods, freq='H')
-    P = pd.DataFrame(data=np.array([4, 4, 4.5, 2.7, 6]), index=index, columns=['Power'])
-    POA = pd.DataFrame(data=np.array([1000,1250,1250,900,1500]), index=index, columns=['POA'])
+    P = pd.Series(data=np.array([4, 4, 4.5, 2.7, 6]), index=index)
+    POA = pd.Series(data=np.array([1000,1250,1250,900,1500]), index=index)
     
     NE = pecos.pv.normalized_efficiency(P, POA, 4, 1000)
-    expected = pd.DataFrame(data=np.array([1.0, 0.8, 0.9, 0.75, 1.0]), index=index, columns=['Normalized Efficiency'])
-    assert_frame_equal(NE, expected, check_dtype=False)
+    expected = pd.Series(data=np.array([1.0, 0.8, 0.9, 0.75, 1.0]), index=index)
+    assert_series_equal(NE, expected, check_dtype=False)
 
 def test_performance_index():
     
     periods = 5
     index = pd.date_range('1/1/2016', periods=periods, freq='H')
-    P = pd.DataFrame(data=np.array([4, 4, 4.5, 2.7, 6]), index=index, columns=['Power'])
-    P_expected = pd.DataFrame(data=np.array([5,10,4.5,3,4]), index=index, columns=['Expected Power'])
+    P = pd.Series(data=np.array([4, 4, 4.5, 2.7, 6]), index=index)
+    P_expected = pd.Series(data=np.array([5,10,4.5,3,4]), index=index)
     
     PI = pecos.pv.performance_index(P, P_expected)
-    expected = pd.DataFrame(data=np.array([0.8,0.4,1,0.9,1.5]), index=index, columns=['Performance Index'])
-    assert_frame_equal(PI, expected, check_dtype=False)
+    expected = pd.Series(data=np.array([0.8,0.4,1,0.9,1.5]), index=index)
+    assert_series_equal(PI, expected, check_dtype=False)
 
 def test_energy_yield():
     
     periods = 5
     index = pd.date_range('1/1/2016', periods=periods, freq='H')
-    E = pd.DataFrame(data=np.array([4, 4, 4.5, 2.7, 6]), index=index, columns=['Energy'])
+    E = pd.Series(data=np.array([4, 4, 4.5, 2.7, 6]), index=index)
     
     EY = pecos.pv.energy_yield(E, 10)
-    expected = pd.DataFrame(data=np.array([0.4,0.4,0.45,0.27,0.6]), index=index, columns=['Energy Yield'])
-    assert_frame_equal(EY, expected, check_dtype=False)
+    expected = pd.Series(data=np.array([0.4,0.4,0.45,0.27,0.6]), index=index)
+    assert_series_equal(EY, expected, check_dtype=False)
 
 def test_clearness_index():
     
     periods = 5
     index = pd.date_range('1/1/2016', periods=periods, freq='H')
-    DNI = pd.DataFrame(data=np.array([4, 4, 4.5, 2.7, 6]), index=index, columns=['DNI'])
-    ExI = pd.DataFrame(data=np.array([5,10,4.5,3,4]), index=index, columns=['ExI'])
+    DNI = pd.Series(data=np.array([4, 4, 4.5, 2.7, 6]), index=index)
+    ExI = pd.Series(data=np.array([5,10,4.5,3,4]), index=index)
     
     K = pecos.pv.clearness_index(DNI, ExI)
-    expected = pd.DataFrame(data=np.array([0.8,0.4,1,0.9,1.5]), index=index, columns=['Clearness Index'])
-    assert_frame_equal(K, expected, check_dtype=False)
+    expected = pd.Series(data=np.array([0.8,0.4,1,0.9,1.5]), index=index)
+    assert_series_equal(K, expected, check_dtype=False)
+
+if __name__ == '__main__':
+    test_performance_ratio()

--- a/pecos/tests/test_utils.py
+++ b/pecos/tests/test_utils.py
@@ -2,7 +2,7 @@ import unittest
 import sys
 from nose import SkipTest
 from nose.tools import *
-from pandas.util.testing import assert_frame_equal
+from pandas.util.testing import assert_frame_equal, assert_index_equal
 import pandas as pd
 import pecos
 
@@ -19,35 +19,52 @@ class TestConvertIndex(unittest.TestCase):
                           '1/1/2016 00:01:14',
                           '1/1/2016 00:01:32',
                           '1/1/2016 00:01:45',
-                          '1/1/2016 00:02:05'])
+                          '1/1/2016 00:02:05',
+                          '1/2/2016 00:00:05'])
     
-        index_int = [14.0,30.0,40.0,44.0,59.0,60.0,74.0,92.0,105.0,125.0]
+        index_float = [14.0,30.0,40.0,44.0,59.0,60.0,74.0,92.0,105.0,125.0,86405.0]
+        index_clock = [14.0,30.0,40.0,44.0,59.0,60.0,74.0,92.0,105.0,125.0,5.0]
         index_epoch = [1451606414.0, 1451606430.0, 1451606440.0, 1451606444.0, 1451606459.0,
-               1451606460.0, 1451606474.0, 1451606492.0, 1451606505.0, 1451606525.0]
+               1451606460.0, 1451606474.0, 1451606492.0, 1451606505.0, 1451606525.0, 1451692805.0]
         
-        data = {'A': range(10)}
+        data = {'A': range(11)}
         self.df_dt = pd.DataFrame(data, index=index_dt)
-        self.df_int = pd.DataFrame(data, index=index_int)
+        self.df_float = pd.DataFrame(data, index=index_float)
+        self.df_clock = pd.DataFrame(data, index=index_clock)
         self.df_epoch = pd.DataFrame(data, index=index_epoch)
         
     @classmethod
     def tearDown(self):
         pass
     
-    def test_convert_index_to_datetime(self):
-        df = pecos.utils.convert_index_to_datetime(self.df_int, unit='s', origin='1/1/2016')
-        assert_frame_equal(df, self.df_dt)
-    
-    def test_convert_index_to_elapsed_time(self):
-        df = pecos.utils.convert_index_to_elapsed_time(self.df_dt, 14.0)
-        assert_frame_equal(df, self.df_int)
-    
-    def test_convert_index_to_epoch_time(self):
+    def test_index_to_datetime(self):
+        index = pecos.utils.index_to_datetime(self.df_float.index, unit='s', origin='1/1/2016')
+        assert_index_equal(index, self.df_dt.index)
+        
+    def test_datetime_to_elapsedtime(self):
+        index = pecos.utils.datetime_to_elapsedtime(self.df_dt.index, 14.0)
+        assert_index_equal(index, self.df_float.index)
+        
+        # with timezone
+        index_tz = self.df_dt.index.tz_localize('MST')
+        index = pecos.utils.datetime_to_elapsedtime(index_tz, 14.0)
+        assert_index_equal(index, self.df_float.index)
+        
+    def test_datetime_to_epochtime(self):
         if sys.version_info.major < 3:
             raise SkipTest # skip if python version < 3
-        df = pecos.utils.convert_index_to_epoch_time(self.df_dt)
-        assert_frame_equal(df, self.df_epoch, check_dtype=False)
-    
+        index = pecos.utils.datetime_to_epochtime(self.df_dt.index)
+        assert_index_equal(index, self.df_epoch.index)
+        
+    def test_datetime_to_clocktime(self):
+        index = pecos.utils.datetime_to_clocktime(self.df_dt.index)
+        assert_index_equal(index, self.df_clock.index)
+        
+        # with timezone
+        index_tz = self.df_dt.index.tz_localize('MST')
+        index = pecos.utils.datetime_to_clocktime(index_tz)
+        assert_index_equal(index, self.df_clock.index)
+        
 class TestRoundIndex(unittest.TestCase):
 
     @classmethod
@@ -70,7 +87,7 @@ class TestRoundIndex(unittest.TestCase):
         pass
     
     def test_round_index_nearest(self):
-        new_df = pecos.utils.round_index(self.df, 15, 'nearest')
+        index = pecos.utils.round_index(self.df.index, 15, 'nearest')
         nearest_index = pd.DatetimeIndex([
                               '1/1/2016 00:00:15', 
                               '1/1/2016 00:00:30',
@@ -82,11 +99,11 @@ class TestRoundIndex(unittest.TestCase):
                               '1/1/2016 00:01:30',
                               '1/1/2016 00:01:45',
                               '1/1/2016 00:02:00'])
-        diff = new_df.index.difference(nearest_index)
+        diff = index.difference(nearest_index)
         assert_equals(len(diff), 0)
     
     def test_round_index_floor(self):
-        new_df = pecos.utils.round_index(self.df, 15, 'floor')
+        index = pecos.utils.round_index(self.df.index, 15, 'floor')
         floor_index = pd.DatetimeIndex([
                               '1/1/2016 00:00:00', 
                               '1/1/2016 00:00:30',
@@ -98,11 +115,11 @@ class TestRoundIndex(unittest.TestCase):
                               '1/1/2016 00:01:30',
                               '1/1/2016 00:01:45',
                               '1/1/2016 00:02:00'])
-        diff = new_df.index.difference(floor_index)
+        diff = index.difference(floor_index)
         assert_equals(len(diff), 0)
     
     def test_round_index_ceiling(self):
-        new_df = pecos.utils.round_index(self.df, 15, 'ceiling')
+        index = pecos.utils.round_index(self.df.index, 15, 'ceiling')
         ceiling_index = pd.DatetimeIndex([
                               '1/1/2016 00:00:15', 
                               '1/1/2016 00:00:30',
@@ -114,12 +131,12 @@ class TestRoundIndex(unittest.TestCase):
                               '1/1/2016 00:01:45',
                               '1/1/2016 00:01:45',
                               '1/1/2016 00:02:15'])
-        diff = new_df.index.difference(ceiling_index)
+        diff = index.difference(ceiling_index)
         assert_equals(len(diff), 0)
     
     def test_round_index_invalid(self):
-        new_df = pecos.utils.round_index(self.df, 15, 'invalid')
-        diff = new_df.index.difference(self.df.index)
+        index = pecos.utils.round_index(self.df.index, 15, 'invalid')
+        diff = index.difference(self.df.index)
         assert_equals(len(diff), 0)
 
 if __name__ == '__main__':

--- a/pecos/tests/test_utils.py
+++ b/pecos/tests/test_utils.py
@@ -1,4 +1,6 @@
 import unittest
+import sys
+from nose import SkipTest
 from nose.tools import *
 from pandas.util.testing import assert_frame_equal
 import pandas as pd
@@ -41,6 +43,8 @@ class TestConvertIndex(unittest.TestCase):
         assert_frame_equal(df, self.df_int)
     
     def test_convert_index_to_epoch_time(self):
+        if sys.version_info.major < 3:
+            raise SkipTest # skip if python version < 3
         df = pecos.utils.convert_index_to_epoch_time(self.df_dt)
         assert_frame_equal(df, self.df_epoch, check_dtype=False)
     

--- a/pecos/tests/test_utils.py
+++ b/pecos/tests/test_utils.py
@@ -8,7 +8,7 @@ class TestConvertIndex(unittest.TestCase):
 
     @classmethod
     def setUp(self):
-        index = pd.DatetimeIndex(['1/1/2016 00:00:14', 
+        index_dt = pd.DatetimeIndex(['1/1/2016 00:00:14', 
                           '1/1/2016 00:00:30',
                           '1/1/2016 00:00:40',
                           '1/1/2016 00:00:44',
@@ -19,22 +19,30 @@ class TestConvertIndex(unittest.TestCase):
                           '1/1/2016 00:01:45',
                           '1/1/2016 00:02:05'])
     
-        index_int = [14,30,40,44,59,60,74,92,105,125]
-
-        self.df = pd.DataFrame(index=index)
-        self.df_int = pd.DataFrame(index=index_int)
+        index_int = [14.0,30.0,40.0,44.0,59.0,60.0,74.0,92.0,105.0,125.0]
+        index_epoch = [1451606414.0, 1451606430.0, 1451606440.0, 1451606444.0, 1451606459.0,
+               1451606460.0, 1451606474.0, 1451606492.0, 1451606505.0, 1451606525.0]
+        
+        data = {'A': range(10)}
+        self.df_dt = pd.DataFrame(data, index=index_dt)
+        self.df_int = pd.DataFrame(data, index=index_int)
+        self.df_epoch = pd.DataFrame(data, index=index_epoch)
         
     @classmethod
     def tearDown(self):
         pass
     
-    def convert_index_to_datetime(self):
+    def test_convert_index_to_datetime(self):
         df = pecos.utils.convert_index_to_datetime(self.df_int, unit='s', origin='1/1/2016')
-        assert_frame_equal(df, self.df)
+        assert_frame_equal(df, self.df_dt)
     
-    def convert_index_to_elapsed_time(self):
-        df_int = pecos.utils.convert_index_to_elapsed_time(self.df)
-        assert_frame_equal(df_int, self.df_int)
+    def test_convert_index_to_elapsed_time(self):
+        df = pecos.utils.convert_index_to_elapsed_time(self.df_dt, 14.0)
+        assert_frame_equal(df, self.df_int)
+    
+    def test_convert_index_to_epoch_time(self):
+        df = pecos.utils.convert_index_to_epoch_time(self.df_dt)
+        assert_frame_equal(df, self.df_epoch)
     
 class TestRoundIndex(unittest.TestCase):
 

--- a/pecos/tests/test_utils.py
+++ b/pecos/tests/test_utils.py
@@ -42,7 +42,7 @@ class TestConvertIndex(unittest.TestCase):
     
     def test_convert_index_to_epoch_time(self):
         df = pecos.utils.convert_index_to_epoch_time(self.df_dt)
-        assert_frame_equal(df, self.df_epoch)
+        assert_frame_equal(df, self.df_epoch, check_dtype=False)
     
 class TestRoundIndex(unittest.TestCase):
 

--- a/pecos/utils.py
+++ b/pecos/utils.py
@@ -38,7 +38,7 @@ def convert_index_to_datetime(data, unit='s', origin='unix'):
         
     return df
 
-def convert_index_to_elapsed_time(data):
+def convert_index_to_elapsed_time(data, origin=0.0):
     """
     Convert DataFrame index from datetime to elapsed time in seconds
     
@@ -46,6 +46,9 @@ def convert_index_to_elapsed_time(data):
     --------------
     data : pandas DataFrame
         Data with DatetimeIndex
+    
+    origin : float
+        Reference for elapsed time
     
     Returns
     ----------
@@ -56,10 +59,31 @@ def convert_index_to_elapsed_time(data):
     df = data.copy()
     
     index = df.index - df.index[0]
-    df.index = index.total_seconds()
+    df.index = index.total_seconds() + origin
     
     return df
-        
+
+def convert_index_to_epoch_time(data):
+    """
+    Convert DataFrame index from datetime to epoch time
+    
+    Parameters
+    --------------
+    data : pandas DataFrame
+        Data with DatetimeIndex
+    
+    Returns
+    ----------
+    pandas DataFrame
+        Data with index in epoch time
+    """
+    
+    df = data.copy()
+    
+    df.index = df.index.astype('int64')/10**9
+    
+    return df
+
 def round_index(data, frequency, how='nearest'):
     """
     Round DataFrame index


### PR DESCRIPTION
This PR includes updates to metrics and helper functions that convert index to/from datetime.  

Most metrics now return 1 value per column in a Pandas Series.  The option to return metrics 'per day' has been removed.  Data can be grouped by custom time intervals by the user before computing metrics.  

pecos.utils includes functions to convert indexes from float/int to datetime, and from datetime to elapsed time, epoch time, and clock time.  Methods ``get_elapsed_time`` and ``get_clock_time`` were removed from the PerformanceMonitoring class. The quality control tests have been tested using data with millisecond resolution.  Time indexes below millisecond can lead to floating point errors.