### PR TITLE
Changes in evaluate string and rolling mean as a preprocessing step

### DIFF
--- a/documentation/qc_tests.rst
+++ b/documentation/qc_tests.rst
@@ -104,14 +104,11 @@ For example, composite signals can be add to the analysis to check for expected 
 vs. measured values (i.e. absolute error or relative error) or an expected
 relationships between data columns (i.e. column A divided by column B).
 An upper bound, lower bound, or both can be specified.
-Additionally, the data can be smoothed using a rolling mean before the test is run.
 Input includes:
 
 * Upper and lower bound
 
 * Data column (default = all columns)
-
-* Rolling window used to smooth the data before test is run (default = 0)
 
 * Minimum number of consecutive failures for reporting (default = 1)
 
@@ -119,18 +116,15 @@ For example,
 
 .. doctest::
 
-    >>> pm.check_range([None, 1], 'A', rolling_mean=2)
+    >>> pm.check_range([None, 1], 'A')
 
-checks for values greater than 1 in the columns associated with the key 'A',
-using a rolling average of 2 time steps.
+checks for values greater than 1 in the columns associated with the key 'A'
 
 Delta test
 --------------------
 The :class:`~pecos.monitoring.PerformanceMonitoring.check_delta` method is used to check for stagnant data and abrupt changes in data.
 The test checks if the difference between the minimum and maximum data value within a moving window is within expected bounds.
 **Currently, this method is not efficient for large data sets (> 100000 pts).**
-Like the check_range method, the user can specify if the data
-should be smoothed using a rolling mean before the test is run.
 Input includes:
 
 * Upper and lower bound
@@ -139,9 +133,7 @@ Input includes:
 
 * Size of the moving window used to compute the difference between the minimum and maximum (default = 3600 seconds)
 
-* Flag indicating if the absolute value is taken (default = True)
-
-* Rolling window used to smooth the data before test is run (default = 0)
+* Flag indicating if the absolute value is used (default = True)
 
 * Minimum number of consecutive failures for reporting (default = 1)
 
@@ -167,8 +159,6 @@ The test checks if the difference between
 consecutive data values (or other specified increment) is within expected bounds.
 This method does not use timestamp indices to find the min and max value within a moving window,
 therefore it is less robust than the check_delta method.
-Like the check_range method, the user can specify if the data
-should be smoothed using a rolling mean before the test is run.
 Input includes:
 
 * Upper and lower bound
@@ -177,9 +167,7 @@ Input includes:
 
 * Increment used for difference calculation (default = 1 timestamp)
 
-* Flag indicating if the absolute value is taken (default = True)
-
-* Rolling window used to smooth the data before test is run (default = 0)
+* Flag indicating if the absolute value is used (default = True)
 
 * Minimum number of consecutive failures for reporting (default = 1)
 
@@ -202,8 +190,6 @@ Outlier test
 The :class:`~pecos.monitoring.PerformanceMonitoring.check_outlier` method is used to check if normalized data
 falls outside expected bounds.  Data is normalized using the mean and standard deviation, using either a
 moving window or using the entire data set.  If multiple columns of data are used, each column is normalized separately.
-Like the check_range method, the user can specify if the data
-should be smoothed using a rolling mean before the test is run.
 Input includes:
 
 * Upper and lower bound (in standard deviations)
@@ -212,9 +198,7 @@ Input includes:
 
 * Size of the moving window used to normalize the data (default = 3600 seconds)
 
-* Flag indicating if the absolute value is taken (default = True)
-
-* Rolling window used to smooth the data before test is run (default = 0)
+* Flag indicating if the absolute value is used (default = True)
 
 * Minimum number of consecutive failures for reporting (default = 1)
 

--- a/documentation/whatsnew/v0.1.8.rst
+++ b/documentation/whatsnew/v0.1.8.rst
@@ -34,5 +34,8 @@ v0.1.8 (master)
 * Timestamp indexes down to millisecond resolution are supported
 * Added additional helper functions in pecos.utils to convert to/from datetime indexes.
   Methods ``get_elapsed_time`` and ``get_clock_time`` were removed from the PerformanceMonitoring class (API change).
+* Moved functionality to evaluate strings from the PerformanceMonitoring class into a stand alone utility function (API change).
+* Removed option to smooth data using a rolling mean within the quality control tests (API change).
+  Preprocessing steps should be done before the quality control test is run. 
 * Added Python 3.7 tests
 * Updated examples, tests, and documentation

--- a/examples/metrics/metrics_example.py
+++ b/examples/metrics/metrics_example.py
@@ -34,8 +34,8 @@ pm.check_corrupt([-999])
 # Check range for all columns
 pm.check_range([0.5,1])
 
-# Check increment for all columns
-pm.check_increment([-0.5, None], absolute_value=False) 
+# Check to see if data decreases by more than -0.5 between consecutive days
+pm.check_increment([-0.5, None], absolute_value=False)  
 
 # Generate graphics
 test_results_graphics = pecos.graphics.plot_test_results(pm.df, pm.test_results)

--- a/examples/pv/pv_example.py
+++ b/examples/pv/pv_example.py
@@ -72,13 +72,16 @@ pm.check_corrupt(corrupt_values)
 # Add composite signals
 for composite_signal in composite_signals:
     for key,value in composite_signal.items():
-        signal = pm.evaluate_string(key, value)
+        signal = pecos.utils.evaluate_string(value, data=pm.df, 
+                                             trans=pm.trans, col_name=key)
         pm.add_dataframe(signal)
         pm.add_translation_dictionary({key: list(signal.columns)})
 
 # Check range
 for key,value in range_bounds.items():
-    pm.check_range(value, key, sapm_parameters) 
+    value[0] = pecos.utils.evaluate_string(value[0], specs=sapm_parameters) 
+    value[1] = pecos.utils.evaluate_string(value[1], specs=sapm_parameters)
+    pm.check_range(value, key) 
 
 # Check increment
 for key,value in increment_bounds.items():

--- a/examples/simple/simple_example_using_config.py
+++ b/examples/simple/simple_example_using_config.py
@@ -29,7 +29,7 @@ pm.add_translation_dictionary(config['Translation'])
 pm.check_timestamp(config['Specifications']['Frequency'])
  
 # Generate a time filter to exclude data points early and late in the day
-time_filter = pm.evaluate_string('Time Filter', config['Time Filter'])
+time_filter = pecos.utils.evaluate_string(config['Time Filter'], df)
 pm.add_time_filter(time_filter)
 
 # Check for missing data
@@ -39,9 +39,10 @@ pm.check_missing()
 pm.check_corrupt(config['Corrupt']) 
 
 # Add a composite signal which compares measurements to a model
+specs = config['Specifications']
 for composite_signal in config['Composite Signals']:
     for key, value in composite_signal.items():
-        signal = pm.evaluate_string(key, value, config['Specifications'])
+        signal = pecos.utils.evaluate_string(value, pm.df, pm.trans, specs, key)
         pm.add_dataframe(signal)
         pm.add_translation_dictionary({key: list(signal.columns)})
 

--- a/pecos/monitoring.py
+++ b/pecos/monitoring.py
@@ -52,7 +52,7 @@ class PerformanceMonitoring(object):
         self.test_results = pd.DataFrame(columns=['Variable Name',
                                                 'Start Time', 'End Time',
                                                 'Timesteps', 'Error Flag'])
-    
+
     @property
     def mask(self):
         """
@@ -95,10 +95,9 @@ class PerformanceMonitoring(object):
         """
         return self.df[self.mask]
 
-    def _setup_data(self, key, window):
+    def _setup_data(self, key):
         """
-        Setup DataFrame, by (optionally) extracting a column and/or smoothing
-        data using rolling window mean.
+        Setup data to use in the quality control test
         """
         if self.df.empty:
             logger.info("Empty database")
@@ -114,14 +113,9 @@ class PerformanceMonitoring(object):
         else:
             df = self.df
 
-        # Compute moving average
-        if window > 0:
-            window_str = str(int(window*1e3)) + 'ms' # milliseconds
-            df = df.rolling(window_str).mean()
-
         return df
 
-    def _generate_test_results(self, df, bound, specs, min_failures, error_prefix):
+    def _generate_test_results(self, df, bound, min_failures, error_prefix):
         """
         Compare DataFrame to bounds to generate a True/False mask where
         True = passed, False = failed.  Append results to test_results.
@@ -131,8 +125,6 @@ class PerformanceMonitoring(object):
         for i in range(len(bound)):
             if bound[i] in none_list:
                 bound[i] = None
-            elif type(bound[i]) is str:
-                bound[i] = self.evaluate_string('', bound[i], specs)
 
         # Lower Bound
         if bound[0] is not None:
@@ -279,39 +271,6 @@ class PerformanceMonitoring(object):
         else:
             self.tfilter = time_filter
 
-#    def add_signal(self, col_name, data):
-#        """
-#        Add signal to the PerformanceMonitoring DataFrame.
-#
-#        Parameters
-#        -----------
-#        col_name : string
-#            Column name to add to translation dictionary
-#
-#        data : pandas DataFrame or pandas Series
-#            Data to add to df
-#        """
-#        if type(data) is pd.core.series.Series:
-#            data = data.to_frame(col_name)
-#        if type(data) is not pd.core.frame.DataFrame:
-#            logger.warning("Add signal failed")
-#            return
-#
-#        if col_name in self.trans.keys():
-#            logger.info(col_name + ' already exists in trans')
-#            return
-#        for col in data.columns.values.tolist():
-#            if col in self.df.columns.values.tolist():
-#                logger.info(col + ' already exists in df')
-#                return
-#        try:
-#            self.trans[col_name] = data.columns.values.tolist()
-#            #self.df[df.columns] = df
-#            for col in data.columns:
-#                self.df[col] = data[col]
-#        except:
-#            logger.warning("Add signal failed: " + col_name)
-#            return
 
     def check_timestamp(self, frequency, expected_start_time=None,
                         expected_end_time=None, min_failures=1,
@@ -417,9 +376,9 @@ class PerformanceMonitoring(object):
                                  use_mask_only=True,
                                  min_failures=min_failures)
 
-    def check_range(self, bound, key=None, specs={}, rolling_mean=0, min_failures=1):
+    def check_range(self, bound, key=None, min_failures=1):
         """
-        Check upper and lower bounds on data
+        Check for data that is outside expected range
 
         Parameters
         ----------
@@ -428,15 +387,8 @@ class PerformanceMonitoring(object):
             or upper bound
 
         key : string (optional)
-            Translation dictionary key.  If not specified, all columns are
-            used in the test.
-
-        specs : dictionary (optional)
-            Constants used in bound
-
-        rolling_mean : int (optional)
-            Size of the moving window (in seconds) used to smooth data using a
-            rolling mean before the test is run, default = 0 (i.e., not used)
+            Data column name or translation dictionary key.  If not specified, 
+            all columns are used in the test.
 
         min_failures : int (optional)
             Minimum number of consecutive failures required for reporting,
@@ -444,19 +396,18 @@ class PerformanceMonitoring(object):
         """
         logger.info("Check data range")
 
-        df = self._setup_data(key, rolling_mean)
+        df = self._setup_data(key)
         if df is None:
             return
 
         error_prefix = 'Data'
 
-        self._generate_test_results(df, bound, specs, min_failures, error_prefix)
+        self._generate_test_results(df, bound, min_failures, error_prefix)
 
-    def check_increment(self, bound, key=None, specs={}, increment=1,
-                        absolute_value=True, rolling_mean=0, min_failures=1):
+    def check_increment(self, bound, key=None, increment=1, absolute_value=True, 
+                        min_failures=1):
         """
-        Check upper and lower bounds on the difference between data values, 
-        separated by a set increment
+        Check data increments using the difference between values
 
         Parameters
         ----------
@@ -465,21 +416,14 @@ class PerformanceMonitoring(object):
             or upper bound
 
         key : string (optional)
-            Translation dictionary key. If not specified, all columns are
-            used in the test.
-
-        specs : dictionary (optional)
-            Constants used in bound
+            Data column name or translation dictionary key. If not specified, 
+            all columns are used in the test.
 
         increment : int (optional)
             Time step shift used to compute difference, default = 1
 
         absolute_value : boolean (optional)
-            Take the absolute value of the increment data, default = True
-
-        rolling_mean : int (optional)
-            Size of the moving window (in seconds) used to smooth data using a
-            rolling mean before the test is run, default = 0 (i.e., not used)
+            Use the absolute value of the increment data, default = True
 
         min_failures : int (optional)
             Minimum number of consecutive failures required for reporting,
@@ -487,7 +431,7 @@ class PerformanceMonitoring(object):
         """
         logger.info("Check increment range")
 
-        df = self._setup_data(key, rolling_mean)
+        df = self._setup_data(key)
         if df is None:
             return
 
@@ -506,13 +450,14 @@ class PerformanceMonitoring(object):
         else:
             error_prefix = 'Increment'
 
-        self._generate_test_results(df, bound, specs, min_failures, error_prefix)
+        self._generate_test_results(df, bound, min_failures, error_prefix)
+    
 
-    def check_delta(self, bound, key=None, specs={}, window=3600,
-                    absolute_value=True, rolling_mean=0, min_failures=1):
+    def check_delta(self, bound, key=None, window=3600, absolute_value=True, 
+                    min_failures=1):
         """
-        Check upper and lower bounds on the difference between max and min data 
-        values within a rolling window
+        Check for stagant data and/or abrupt changes in the data using the 
+        difference between max and min values within a rolling window
           
         Note, this method is currently NOT efficient for large
         data sets (> 100000 pts) because it uses df.rolling().apply() to find
@@ -525,22 +470,15 @@ class PerformanceMonitoring(object):
             or upper bound
 
         key : string (optional)
-            Translation dictionary key. If not specified, all columns are used
-            in the test.
-
-        specs : dictionary (optional)
-            Constants used in bound
+            Data column name or translation dictionary key. If not specified, 
+            all columns are used in the test.
 
         window : int (optional)
-            Size of the moving window (in seconds) used to compute delta,
+            Size of the rolling window (in seconds) used to compute delta,
             default = 3600
 
         absolute_value : boolean (optional)
-            Take the absolute value of delta, default = True
-
-        rolling_mean : int (optional)
-            Size of the moving window (in seconds) used to smooth data using a
-            rolling mean before the test is run, default = 0 (i.e., not used)
+            Use the absolute value of delta, default = True
 
         min_failures : int (optional)
             Minimum number of consecutive failures required for reporting,
@@ -548,7 +486,7 @@ class PerformanceMonitoring(object):
         """
         logger.info("Check delta (max-min) range")
         
-        df = self._setup_data(key, rolling_mean)
+        df = self._setup_data(key)
         if df is None:
             return
 
@@ -595,8 +533,6 @@ class PerformanceMonitoring(object):
         for i in range(len(bound)):
             if bound[i] in none_list:
                 bound[i] = None
-            elif type(bound[i]) is str:
-                bound[i] = self.evaluate_string('', bound[i], specs)
 
         def extract_exact_position(mask1, tmin_df, tmax_df):
             mask2 = pd.DataFrame(False, columns=mask1.columns, index=mask1.index)
@@ -634,11 +570,10 @@ class PerformanceMonitoring(object):
                 self._append_test_results(mask, error_prefix+' > upper bound, '+str(bound[1]),
                                          min_failures=min_failures)
 
-    def check_outlier(self, bound, key=None, specs={}, window=3600,
-                        absolute_value=True, rolling_mean=0, min_failures=1):
+    def check_outlier(self, bound, key=None, window=3600, absolute_value=True, 
+                      min_failures=1):
         """
-        Check upper and lower bounds on normalized data within a moving window
-        to find outliers
+        Check for outliers using normalized data within a rolling window
         
         The upper and lower bounds are specified in standard deviations.
         Data normalized using (data-mean)/std.
@@ -650,23 +585,16 @@ class PerformanceMonitoring(object):
             or upper bound
 
         key : string (optional)
-            Translation dictionary key. If not specified, all columns are used
-            in the test.
-
-        specs : dictionary (optional)
-            Constants used in bound
+            Data column name or translation dictionary key. If not specified, 
+            all columns are used in the test.
 
         window : int or None (optional)
-            Size of the moving window (in seconds) used to normalize data,
+            Size of the rolling window (in seconds) used to normalize data,
             default = 3600.  If window is set to None, data is normalized using
             the entire data sets mean and standard deviation (column by column).
 
         absolute_value : boolean (optional)
-            Take the absolute value the normalized data, default = True
-
-        rolling_mean : int (optional)
-            Size of the moving window (in seconds) used to smooth data using a
-            rolling mean before the test is run, default = 0 (i.e., not used)
+            Use the absolute value the normalized data, default = True
 
         min_failures : int (optional)
             Minimum number of consecutive failures required for reporting,
@@ -674,7 +602,7 @@ class PerformanceMonitoring(object):
         """
         logger.info("Check for outliers")
 
-        df = self._setup_data(key, rolling_mean)
+        df = self._setup_data(key)
         if df is None:
             return
 
@@ -695,7 +623,7 @@ class PerformanceMonitoring(object):
 
         #df[df.index[0]:df.index[0]+datetime.timedelta(seconds=window)] = np.nan
 
-        self._generate_test_results(df, bound, specs, min_failures, error_prefix)
+        self._generate_test_results(df, bound, min_failures, error_prefix)
 
     def check_missing(self, key=None, min_failures=1):
         """
@@ -704,8 +632,8 @@ class PerformanceMonitoring(object):
         Parameters
         ----------
         key : string (optional)
-            Translation dictionary key. If not specified, all columns are used
-            in the test.
+            Data column name or translation dictionary key. If not specified, 
+            all columns are used in the test.
 
         min_failures : int (optional)
             Minimum number of consecutive failures required for reporting,
@@ -713,7 +641,7 @@ class PerformanceMonitoring(object):
         """
         logger.info("Check for missing data")
 
-        df = self._setup_data(key, 0)
+        df = self._setup_data(key)
         if df is None:
             return
 
@@ -737,8 +665,8 @@ class PerformanceMonitoring(object):
             List of corrupt data values
 
         key : string (optional)
-            Translation dictionary key. If not specified, all columns are used
-            in the test.
+            Data column name or translation dictionary key. If not specified, 
+            all columns are used in the test.
 
         min_failures : int (optional)
             Minimum number of consecutive failures required for reporting,
@@ -746,7 +674,7 @@ class PerformanceMonitoring(object):
         """
         logger.info("Check for corrupt data")
 
-        df = self._setup_data(key, 0)
+        df = self._setup_data(key)
         if df is None:
             return
 
@@ -846,47 +774,47 @@ def check_timestamp(data, frequency, expected_start_time=None,
 
 
 @_documented_by(PerformanceMonitoring.check_range)
-def check_range(data, bound, key=None, specs={}, rolling_mean=0, min_failures=1):
+def check_range(data, bound, key=None, min_failures=1):
 
     pm = PerformanceMonitoring()
     pm.add_dataframe(data)
-    pm.check_range(bound, key, specs, rolling_mean, min_failures)
+    pm.check_range(bound, key, min_failures)
     mask = pm.mask
 
     return {'cleaned_data': data[mask], 'mask': mask, 'test_results': pm.test_results}
 
 
 @_documented_by(PerformanceMonitoring.check_increment)
-def check_increment(data, bound, key=None, specs={}, increment=1, absolute_value=True,
-                    rolling_mean=0, min_failures=1):
+def check_increment(data, bound, key=None, increment=1, absolute_value=True,
+                    min_failures=1):
 
     pm = PerformanceMonitoring()
     pm.add_dataframe(data)
-    pm.check_increment(bound, key, specs, increment, absolute_value, rolling_mean, min_failures)
+    pm.check_increment(bound, key, increment, absolute_value, min_failures)
     mask = pm.mask
 
     return {'cleaned_data': data[mask], 'mask': mask, 'test_results': pm.test_results}
 
 
 @_documented_by(PerformanceMonitoring.check_delta)
-def check_delta(data, bound, key=None, specs={}, window=3600, absolute_value=True,
-                rolling_mean=0, min_failures=1):
+def check_delta(data, bound, key=None, window=3600, absolute_value=True,
+                min_failures=1):
 
     pm = PerformanceMonitoring()
     pm.add_dataframe(data)
-    pm.check_delta(bound, key, specs, window, absolute_value, rolling_mean, min_failures)
+    pm.check_delta(bound, key, window, absolute_value, min_failures)
     mask = pm.mask
 
     return {'cleaned_data': data[mask], 'mask': mask, 'test_results': pm.test_results}
 
 
 @_documented_by(PerformanceMonitoring.check_outlier)
-def check_outlier(data, bound, key=None, specs={}, window=3600, absolute_value=True,
-                  rolling_mean=0, min_failures=1):
+def check_outlier(data, bound, key=None, window=3600, absolute_value=True,
+                  min_failures=1):
 
     pm = PerformanceMonitoring()
     pm.add_dataframe(data)
-    pm.check_outlier(bound, None, {}, window, absolute_value, rolling_mean, min_failures)
+    pm.check_outlier(bound, None, window, absolute_value, min_failures)
     mask = pm.mask
 
     return {'cleaned_data': data[mask], 'mask': mask, 'test_results': pm.test_results}

--- a/pecos/tests/test_monitoring.py
+++ b/pecos/tests/test_monitoring.py
@@ -98,17 +98,6 @@ class Test_simple_example(unittest.TestCase):
     @classmethod
     def tearDown(self):
         pass
-    
-    def test_evaluate_string(self):
-        time_filter_string = "({CLOCK_TIME} > 3*3600) & ({CLOCK_TIME} < 21*3600)"
-        time_filter = self.pm.evaluate_string('Time Filter', time_filter_string)
-        
-        expected = pd.DataFrame(index=self.pm.df.index, columns=['Time Filter'])
-        expected['Time Filter'] = False
-        expected[(self.pm.df.index > pd.Timestamp('2015-01-01 03:00:00')) & 
-                 (self.pm.df.index < pd.Timestamp('2015-01-01 21:00:00'))] = True
-                
-        assert_frame_equal(time_filter, expected, check_dtype=False)
         
     def test_check_timestamp(self):
         #Missing timestamp at 5:00

--- a/pecos/utils.py
+++ b/pecos/utils.py
@@ -1,7 +1,9 @@
 """
 The utils module contains helper functions.
 """
+import numpy as np
 import pandas as pd
+import re
 import logging
 
 logger = logging.getLogger(__name__)
@@ -113,9 +115,7 @@ def round_index(index, frequency, how='nearest'):
         Method for rounding, default = 'nearest'.  Options include:
         
         * nearest = round the index to the nearest frequency
-        
         * floor = round the index to the smallest expected frequency
-        
         * ceiling = round the index to the largest expected frequency 
         
     Returns
@@ -137,3 +137,110 @@ def round_index(index, frequency, how='nearest'):
         rounded_index = index
 
     return rounded_index
+
+
+def evaluate_string(string_to_eval, data=None, trans=None, specs=None, col_name='eval'):
+    """
+    Returns an evaluated Python string.  WARNING this function calls 'eval'. 
+    Strings of Python code should be thoroughly tested by the user.
+    
+    This function can be useful when defining quality control configuration 
+    options in a file, such as:
+    
+    * Time filters that depend on the data index
+    * Quality control bounds that depend on system constants
+    * Composite signals that are defined using existing data
+    
+    For each {keyword} in string_to_eval, {keyword} is expanded in the following order:
+    
+    * If keyword is ELAPSED_TIME, CLOCK_TIME or EPOCH_TIME then data.index is 
+      converted to seconds (elapsed time, clock time, or epoch time) and used 
+      in the evaluation (requires data)
+    * If keyword is used to select a column (or columns) of data, then 
+      data[keyword] is used in the evaluation (requires data) 
+    * If a translation dictionary is used to select a column (or columns) of data, then 
+      data[trans[keyword]] is used in the evaluation (requires data and trans) 
+    * If the keyword is a key in a dictionary of constants, specs, then 
+      specs[keyword] is used in the evaluation (requires specs)
+
+    Parameters
+    ----------
+    string_to_eval : string
+        String to evaluate, the string can included multiple keywords and 
+        numpy (np.*) and pandas (pd.*) functions
+    data : pandas DataFrame (optional)
+        Data, indexed by datetime
+    trans: dictionary (optional)
+        Translation dictionary
+    specs : dictionary (optional)
+        Keyword:value pairs used to define constants
+    col_name : string (optional)
+        Column name used in the returned DataFrame.  If the DataFrame has more 
+        than one column, columns are named col_name 0, col_name 1, ...
+        
+    Returns
+    --------
+    pandas DataFrame or float
+        Evaluated string
+    """
+
+    if not isinstance(string_to_eval, str):
+        return string_to_eval
+    
+    match = re.findall(r"\{(.*?)\}", string_to_eval)
+    for m in set(match):
+        m = m.replace('[','') # check for list
+
+        if m == 'ELAPSED_TIME':
+            ELAPSED_TIME = datetime_to_elapsedtime(data.index)
+            ELAPSED_TIME = pd.Series(ELAPSED_TIME, index=data.index)
+            string_to_eval = string_to_eval.replace("{"+m+"}",m)
+        elif m == 'CLOCK_TIME':
+            CLOCK_TIME = datetime_to_clocktime(data.index)
+            CLOCK_TIME = pd.Series(CLOCK_TIME, index=data.index)
+            string_to_eval = string_to_eval.replace("{"+m+"}",m)
+        elif m == 'EPOCH_TIME':
+            EPOCH_TIME = datetime_to_epochtime(data.index)
+            EPOCH_TIME = pd.Series(EPOCH_TIME, index=data.index)
+            string_to_eval = string_to_eval.replace("{"+m+"}",m)
+        else:
+            try:
+                data[m]
+                datastr = "data[['" + m + "']]" # dataframe
+                string_to_eval = string_to_eval.replace("{"+m+"}",datastr)
+            except:
+                try:
+                    data[trans[m]]
+                    datastr = "data[trans['" + m + "']]"
+                    string_to_eval = string_to_eval.replace("{"+m+"}",datastr)
+                except:
+                    try:
+                        specs[m]
+                        datastr = "specs['" + m + "']"
+                        string_to_eval = string_to_eval.replace("{"+m+"}",datastr)
+                    except:
+                        pass
+
+    try:
+        signal = eval(string_to_eval)
+        
+        # Convert Series and tuple of Series to DataFrame
+        if isinstance(signal, pd.Series): # Series
+            signal = signal.to_frame(0)
+        elif isinstance(signal, tuple): # A tuple of series
+            signal = pd.DataFrame(signal).T
+        
+        assert isinstance(signal, (pd.DataFrame, int, float))
+        
+        # If DataFrame, update column names
+        if isinstance(signal, pd.DataFrame): 
+            if len(signal.columns) == 1:
+                signal.columns = [col_name]
+            else:
+                signal.columns = [col_name + " " + str(i) for i in range(len(signal.columns))]
+        
+    except:
+        signal = None
+
+    return signal
+    

--- a/pecos/utils.py
+++ b/pecos/utils.py
@@ -120,8 +120,8 @@ def round_index(index, frequency, how='nearest'):
         
     Returns
     -------
-    pandas Datarame
-        Data with rounded datetime index
+    pandas Index
+        DataFrame index with rounded values
     """
 
     window_str=str(int(frequency*1e3)) + 'ms' # milliseconds


### PR DESCRIPTION
* This PR moves functionality to evaluates strings from the PerformanceMonitoring class into a stand alone function in pecos.utils. This function can be used to evaluate strings that are defined in a configuration file, such as time filters, composite signals, and bounds.
* The PR also removed the option to smooth data using a rolling mean from within a quality control test.  Preprocessing steps like this should be done outside the quality control test.  Removing this option also helps clarify when rolling windows are used in a quality control tests (delta and outlier test).
* These updates remove `specs` and `rolling_mean` as optional input arguments to quality control tests.
* Tests and documentation have been updated