### PR TITLE
Fix: import fails due to pytest ModuleNotFoundError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pandas
 numpy
 jinja2
 matplotlib
-pytest
+
 
 # Optional
 pvlib
@@ -16,4 +16,5 @@ sphinx
 sphinx_rtd_theme
 
 # Testing
+pytest
 coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pandas
 numpy
 jinja2
 matplotlib
+pytest
 
 # Optional
 pvlib
@@ -15,5 +16,4 @@ sphinx
 sphinx_rtd_theme
 
 # Testing
-pytest
 coverage

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setuptools_kwargs = {
     'install_requires': ['numpy >= 1.10.4',
                          'pandas >= 0.18.0',
                          'matplotlib',
-                         'jinja2'],
+                         'jinja2'
+                         'pytest'],
     'scripts': [],
     'include_package_data': True
 }

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools_kwargs = {
     'install_requires': ['numpy >= 1.10.4',
                          'pandas >= 0.18.0',
                          'matplotlib',
-                         'jinja2'
+                         'jinja2',
                          'pytest'],
     'scripts': [],
     'include_package_data': True


### PR DESCRIPTION
`import pecos` currently fails due to `pytest` being called on this line: https://github.com/sandialabs/pecos/blob/e0aea99535f92f6f63f38387a79898ccb6966f37/pecos/graphics.py#L423

This commit moves pytest up to the required section of `requirements.txt` which allows pytest to be installed during the `pip` installation step.