### PR TITLE
minor fix testing (pyyaml added in requirements)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 _build/
 pecos.egg-info/*
 logfile
+build/
+dist/
 
 *.html
 *.csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ sphinx_rtd_theme
 # Testing
 pytest
 coverage
+pyyaml


### PR DESCRIPTION
pyyaml needed in requirements to run `pecos/examples/pv/pv_example.py`.

Somehow it still gives me an error in the following line:
https://github.com/sandialabs/pecos/blob/7819b9e1e847967edd8707b63df3644b3adea3e4/examples/pv/pv_example.py#L103

I encountered the following error when running the script:

```python
Exception has occurred: ValueError
Axis limits cannot be NaN or Inf
  File "C:\Users\...\pecos\examples\pv\pv_example.py", line 103, in <module>
    test_results_graphics = pecos.graphics.plot_test_results(pm.data, pm.test_results, pm.tfilter)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Axis limits cannot be NaN or Inf

