### PR TITLE
Capped Pandas below 3.0 and updated Python versions for testing

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -24,7 +24,7 @@ jobs:
           git remote -v
       - uses: actions/setup-python@v2
         with: 
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install package
         run: |
           pip install -e .

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install pecos
       run: |
         python -m pip install --upgrade pip
-        pip install wheel numpy pandas jinja2 matplotlib pytest
+        pip install wheel numpy pandas<3.0 jinja2 matplotlib pytest
         pip install --no-index --pre --find-links=. pecos
     - name: Import pecos
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -66,9 +66,9 @@ jobs:
     - name: Download wheel
       uses: actions/download-artifact@v4
       with:
-        #name: pecos_${{ matrix.python-version }}_${{ matrix.os }}.whl
-        pattern: "pecos_*"
-        merge-multiple: true
+        name: pecos_${{ matrix.python-version }}_${{ matrix.os }}.whl
+        #pattern: "pecos_*"
+        #merge-multiple: true
     - name: Install pecos
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -26,6 +26,8 @@ jobs:
       uses: actions/checkout@v4
     - name: Build wheels
       run: |
+        python -m pip install --upgrade pip
+        pip install setuptools
         python setup.py bdist_wheel
         ls dist/*
     - name: Save wheel

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -22,26 +22,30 @@ jobs:
         os: [windows-latest, macOS-latest, ubuntu-latest]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python --version
-        python -m pip install --upgrade pip
-        pip install wheel
-        pip install -r requirements.txt
-    - name: Build wheel
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Build wheels
       run: |
         python setup.py bdist_wheel
         ls dist/*
-    - name: Upload wheels
+    - name: Save wheel
       uses: actions/upload-artifact@v4
       with:
         name: pecos_${{ matrix.python-version }}_${{ matrix.os }}.whl
         path: dist/pecos*
+    - name: Set up Python for twine verification
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install twine and verify wheels
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine
+        for wheel in ./dist/pecos*; do
+          echo "Verifying wheel: $wheel"
+          twine check "$wheel"
+        done
 
   test_wheels:
     name: Test wheels
@@ -60,11 +64,13 @@ jobs:
     - name: Download wheel
       uses: actions/download-artifact@v4
       with:
-        name: pecos_${{ matrix.python-version }}_${{ matrix.os }}.whl
+        #name: pecos_${{ matrix.python-version }}_${{ matrix.os }}.whl
+        pattern: "pecos_*"
+        merge-multiple: true
     - name: Install pecos
       run: |
         python -m pip install --upgrade pip
-        pip install wheel numpy pandas<3.0 jinja2 matplotlib pytest
+        pip install wheel numpy "pandas<3.0" jinja2 matplotlib pytest setuptools
         pip install --no-index --pre --find-links=. pecos
     - name: Import pecos
       run: |
@@ -110,7 +116,7 @@ jobs:
     - name: Set up Python 
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.11
     - uses: actions/checkout@v4
     - name: Install coverage
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [windows-latest, macOS-latest, ubuntu-latest]
       fail-fast: false
     steps:
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [windows-latest, macOS-latest, ubuntu-latest]
       fail-fast: false
     steps:
@@ -74,7 +74,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [windows-latest, macOS-latest, ubuntu-latest]
       fail-fast: false
     steps:
@@ -110,7 +110,7 @@ jobs:
     - name: Set up Python 
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
     - uses: actions/checkout@v4
     - name: Install coverage
       run: |

--- a/.github/workflows/quick_check.yml
+++ b/.github/workflows/quick_check.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install packages
       run: |
         python -m pip install --upgrade pip

--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -30,7 +30,8 @@ Developers can install the main branch of Pecos from the GitHub repository using
 
 	git clone https://github.com/sandialabs/pecos
 	cd pecos
-	python setup.py install
+	python -m pip install -e .
+	pip install -r requirements.txt
 
 To install Pecos using a downloaded zip file, go to https://github.com/sandialabs/pecos, 
 select the "Clone or download" button and then select "Download ZIP".
@@ -40,7 +41,8 @@ The software can then be installed by unzipping the file and running setup.py::
 
 	unzip pecos-main.zip
 	cd pecos-main
-	python setup.py install
+	python -m pip install -e .
+	pip install -r requirements.txt
 
 To use Pecos, import the package from a Python console::
 

--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ======================================
 
-Pecos requires Python (tested on 3.9, 3.10, 3.11, and 3.12) along with several Python 
+Pecos requires Python (tested on 3.10, 3.11, 3.12, and 3.13) along with several Python 
 package dependencies.  Information on installing and using Python can be found at 
 https://www.python.org/.  Python distributions, such as Anaconda,
 are recommended to manage the Python interface.  

--- a/pecos/__init__.py
+++ b/pecos/__init__.py
@@ -6,7 +6,7 @@ from pecos import logger
 from pecos import utils
 from pecos import pv
 
-__version__ = '1.0.0'
+__version__ = '1.1.0dev1'
 
 __copyright__ = """Copyright 2016 National Technology & Engineering 
     Solutions of Sandia, LLC (NTESS). Under the terms of Contract 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required
-pandas
+pandas<3.0
 numpy
 jinja2
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ URL = 'https://github.com/sandialabs/pecos'
 setuptools_kwargs = {
     'zip_safe': False,
     'install_requires': ['numpy >= 1.10.4',
-                         'pandas >= 0.18.0',
+                         'pandas >= 0.18.0,<3.0',
                          'matplotlib',
                          'jinja2',
                          'pytest'],


### PR DESCRIPTION
This PR includes the following updates:
- Capped Pandas dependency below 3.0, deprecation errors will be addressed soon
- Added Python 3.13 and dropped 3.9 in the testing workflow
- Updated installation instructions